### PR TITLE
Feature/add viewmodel layer

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -43,6 +43,9 @@ android {
 }
 
 dependencies {
+    // ViewModel Dependency
+    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.10.0")
+
     // Room Database
     val room_version = "2.7.1"
     implementation("androidx.room:room-runtime:$room_version")

--- a/app/src/main/java/com/example/ordermanagementcake/data/local/OrderDatabase.kt
+++ b/app/src/main/java/com/example/ordermanagementcake/data/local/OrderDatabase.kt
@@ -4,12 +4,16 @@ import android.content.Context
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
+import androidx.sqlite.db.SupportSQLiteDatabase
 import com.example.ordermanagementcake.data.local.dao.ClientDao
 import com.example.ordermanagementcake.data.local.dao.OrderDao
 import com.example.ordermanagementcake.data.local.dao.OrderItemDao
 import com.example.ordermanagementcake.data.local.entities.ClientEntity
 import com.example.ordermanagementcake.data.local.entities.OrderEntity
 import com.example.ordermanagementcake.data.local.entities.OrderItemEntity
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
 // degfine nia database Room iah ne'e
 @Database (
@@ -36,8 +40,23 @@ abstract class OrderDatabase: RoomDatabase() {
                     context.applicationContext,
                     OrderDatabase::class.java,
                     "order_management_db"
-                ).build().also { INSTANCE = it }
+                )
+                    .addCallback(PrepopulateCallback())
+                    .build()
+                    .also { INSTANCE = it }
+            }
+        }
+    }
+    private class PrepopulateCallback : Callback() {
+        override fun onCreate(db: SupportSQLiteDatabase) {
+            super.onCreate(db)
+            INSTANCE?.let { database ->
+                CoroutineScope(Dispatchers.IO).launch {
+                    seedDatabase(database)  // ← calls your seed function
+                }
             }
         }
     }
 }
+
+

--- a/app/src/main/java/com/example/ordermanagementcake/data/local/SeedData.kt
+++ b/app/src/main/java/com/example/ordermanagementcake/data/local/SeedData.kt
@@ -1,0 +1,39 @@
+package com.example.ordermanagementcake.data.local
+
+import com.example.ordermanagementcake.data.local.entities.ClientEntity
+import com.example.ordermanagementcake.data.local.entities.OrderEntity
+import com.example.ordermanagementcake.data.local.entities.OrderItemEntity
+
+suspend fun seedDatabase(database: OrderDatabase) {
+    val clientDao = database.clientDao()
+    val orderDao  = database.orderDao()
+    val itemDao   = database.orderItemDao()
+
+    val clientIds = listOf(
+        ClientEntity(name = "Eleanor Rigby",    phoneNumber = "+670 77100001", address = "Dili, Timor-Leste",  createdAt = "2026-01-10"),
+        ClientEntity(name = "Arthur Dent",      phoneNumber = "+670 77100002", address = "Baucau, Timor-Leste", createdAt = "2026-01-15"),
+        ClientEntity(name = "Sarah Jenkins",    phoneNumber = "+670 77100003", address = "Dili, Timor-Leste",  createdAt = "2026-02-01"),
+        ClientEntity(name = "Michael Scott",    phoneNumber = "+670 77100004", address = "Dili, Timor-Leste",  createdAt = "2026-02-14"),
+        ClientEntity(name = "Abinda Carmo",     phoneNumber = "+670 76534263", address = "Dili, Timor-Leste",  createdAt = "2026-03-01"),
+        ClientEntity(name = "Chrismerry Carmo", phoneNumber = "+670 76588263", address = "Dili, Timor-Leste",  createdAt = "2026-03-05")
+    ).map { clientDao.insertClient(it) }
+
+    val orderIds = listOf(
+        OrderEntity(clientId = clientIds[0].toInt(), orderDate = "2026-04-10", pickupDate = "Oct 24, 14:00", status = "PENDING",     notes = "Extra fudge on top",       createdAt = "2026-04-10"),
+        OrderEntity(clientId = clientIds[1].toInt(), orderDate = "2026-04-10", pickupDate = "Oct 24, 16:30", status = "PENDING",     notes = "Allergy: no nuts",         createdAt = "2026-04-10"),
+        OrderEntity(clientId = clientIds[2].toInt(), orderDate = "2026-04-11", pickupDate = "Today, 10:00",  status = "IN_PROGRESS", notes = "Write Happy Birthday Ana", createdAt = "2026-04-11"),
+        OrderEntity(clientId = clientIds[3].toInt(), orderDate = "2026-04-08", pickupDate = "Yesterday",     status = "COMPLETED",   notes = "5-tier wedding cake",      createdAt = "2026-04-08"),
+        OrderEntity(clientId = clientIds[4].toInt(), orderDate = "2026-04-12", pickupDate = "Apr 15, 09:00", status = "READY",       notes = "Box with ribbon please",   createdAt = "2026-04-12"),
+        OrderEntity(clientId = clientIds[5].toInt(), orderDate = "2026-04-13", pickupDate = "Apr 16, 11:00", status = "IN_PROGRESS", notes = "Gluten free base",         createdAt = "2026-04-13")
+    ).map { orderDao.insertOrder(it) }
+
+    listOf(
+        OrderItemEntity(orderId = orderIds[0].toInt(), title = "Double Chocolate Fudge", description = "8 inch, dark chocolate ganache", imageRef = "double_chodolate_fudge", quantity = 1,  notes = "Extra fudge on top"),
+        OrderItemEntity(orderId = orderIds[1].toInt(), title = "Wild Berry Medley",       description = "6 inch, mixed berry compote",    imageRef = "wild_berry",              quantity = 2,  notes = "No nuts"),
+        OrderItemEntity(orderId = orderIds[2].toInt(), title = "Zesty Lemon Drizzle",     description = "6 inch, lemon curd filling",     imageRef = "lemon_drizzle",           quantity = 1,  notes = "Happy Birthday Ana"),
+        OrderItemEntity(orderId = orderIds[3].toInt(), title = "Custom Wedding Tier",     description = "5 tiers, white fondant",         imageRef = "wedding_cake",            quantity = 1,  notes = ""),
+        OrderItemEntity(orderId = orderIds[4].toInt(), title = "Salted Caramel Macaron",  description = "Tower of 24 macarons",           imageRef = "macaron_tower",           quantity = 1,  notes = "Ribbon box"),
+        OrderItemEntity(orderId = orderIds[4].toInt(), title = "Vanilla Cupcakes",        description = "Box of 12, vanilla buttercream", imageRef = "vanilla_cupcakes",        quantity = 12, notes = ""),
+        OrderItemEntity(orderId = orderIds[5].toInt(), title = "Gluten Free Carrot Cake", description = "8 inch, cream cheese frosting",  imageRef = "carrot_cake",             quantity = 1,  notes = "Gluten free base")
+    ).forEach { itemDao.insertItem(it) }
+}

--- a/app/src/main/java/com/example/ordermanagementcake/data/local/relations/ClientRepository.kt
+++ b/app/src/main/java/com/example/ordermanagementcake/data/local/relations/ClientRepository.kt
@@ -1,0 +1,26 @@
+package com.example.ordermanagementcake.data.local.relations
+
+import com.example.ordermanagementcake.data.local.dao.ClientDao
+import com.example.ordermanagementcake.data.local.entities.ClientEntity
+import kotlinx.coroutines.flow.Flow
+
+class ClientRepository(private val clientDao: ClientDao) {
+
+    fun getAllClients(): Flow<List<ClientEntity>> =
+        clientDao.getAllCLients()
+
+    fun getClientWithOrders(id: Int): Flow<ClientWithOrder> =
+        clientDao.getClientWithOrder(id)
+
+    suspend fun findByWhatsapp(phoneNumber: String): ClientEntity? =
+        clientDao.findByWhatsapp(phoneNumber)
+
+    suspend fun insertClient(client: ClientEntity): Long =
+        clientDao.insertClient(client)
+
+    suspend fun updateClient(client: ClientEntity) =
+        clientDao.updateClient(client)
+
+    suspend fun deleteClient(client: ClientEntity) =
+        clientDao.deleteClient(client)
+}

--- a/app/src/main/java/com/example/ordermanagementcake/data/repository/ClientRepository.kt
+++ b/app/src/main/java/com/example/ordermanagementcake/data/repository/ClientRepository.kt
@@ -1,7 +1,8 @@
-package com.example.ordermanagementcake.data.local.relations
+package com.example.ordermanagementcake.data.repository
 
 import com.example.ordermanagementcake.data.local.dao.ClientDao
 import com.example.ordermanagementcake.data.local.entities.ClientEntity
+import com.example.ordermanagementcake.data.local.relations.ClientWithOrder
 import kotlinx.coroutines.flow.Flow
 
 class ClientRepository(private val clientDao: ClientDao) {

--- a/app/src/main/java/com/example/ordermanagementcake/data/repository/OrderRepository.kt
+++ b/app/src/main/java/com/example/ordermanagementcake/data/repository/OrderRepository.kt
@@ -1,0 +1,27 @@
+package com.example.ordermanagementcake.data.repository
+
+import com.example.ordermanagementcake.data.local.dao.OrderDao
+import com.example.ordermanagementcake.data.local.entities.OrderEntity
+import com.example.ordermanagementcake.data.local.relations.OrderWithItems
+import kotlinx.coroutines.flow.Flow
+
+class OrderRepository(private val orderDao: OrderDao) {
+
+    fun getOrdersByStatus(status: String): Flow<List<OrderEntity>> =
+        orderDao.getOrdersByStatus(status) // funciton iha Repository ne'e atu retorna deit valor husi Dao nian (return orderDao.getORderByStatus(status())
+
+    fun getOrderWithItems(id: Int): Flow<OrderWithItems?> =
+        orderDao.getOrderWithItems(id)
+
+    suspend fun insertOrder(order: OrderEntity): Long =
+        orderDao.insertOrder(order)
+
+    suspend fun updateOrder(order: OrderEntity) =
+        orderDao.updateOrder(order)
+
+    suspend fun updateStatus(orderId: Int, status: String) =
+        orderDao.updateStatus(orderId, status)
+
+    suspend fun deleteOrder(order: OrderEntity) =
+        orderDao.deleteOrder(order)
+}

--- a/app/src/main/java/com/example/ordermanagementcake/ui/clients/ClientUiState.kt
+++ b/app/src/main/java/com/example/ordermanagementcake/ui/clients/ClientUiState.kt
@@ -1,0 +1,10 @@
+package com.example.ordermanagementcake.ui.clients
+
+import com.example.ordermanagementcake.data.local.entities.ClientEntity
+
+data class ClientUiState(
+    val clients: List<ClientEntity> = emptyList(),
+    val isLoading: Boolean = true,
+    val errorMessage: String? = null,
+    val searchQuery: String = ""
+)

--- a/app/src/main/java/com/example/ordermanagementcake/ui/clients/ClientViewModel.kt
+++ b/app/src/main/java/com/example/ordermanagementcake/ui/clients/ClientViewModel.kt
@@ -1,0 +1,57 @@
+package com.example.ordermanagementcake.ui.clients
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.ordermanagementcake.data.local.entities.ClientEntity
+import com.example.ordermanagementcake.data.repository.ClientRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+class ClientViewModel(private val repository: ClientRepository) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(ClientUiState())
+    val uiState: StateFlow<ClientUiState> = _uiState.asStateFlow()
+
+    init {
+        loadClients()
+    }
+
+    fun loadClients() {
+        _uiState.update { it.copy(isLoading = true, errorMessage = null) }
+        viewModelScope.launch {
+            repository.getAllClients()
+                .catch { e ->
+                    _uiState.update { it.copy(isLoading = false, errorMessage = e.message) }
+                }
+                .collect { clients ->
+                    _uiState.update { it.copy(clients = clients, isLoading = false) }
+                }
+        }
+    }
+
+    fun onSearchQueryChange(query: String) {
+        _uiState.update { it.copy(searchQuery = query) }
+    }
+
+    fun insertClient(client: ClientEntity) {
+        viewModelScope.launch {
+            repository.insertClient(client)
+        }
+    }
+
+    fun updateClient(client: ClientEntity) {
+        viewModelScope.launch {
+            repository.updateClient(client)
+        }
+    }
+
+    fun deleteClient(client: ClientEntity) {
+        viewModelScope.launch {
+            repository.deleteClient(client)
+        }
+    }
+}

--- a/app/src/main/java/com/example/ordermanagementcake/ui/clients/ClientViewModelFactory.kt
+++ b/app/src/main/java/com/example/ordermanagementcake/ui/clients/ClientViewModelFactory.kt
@@ -1,0 +1,15 @@
+package com.example.ordermanagementcake.ui.clients
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.example.ordermanagementcake.data.repository.ClientRepository
+
+class ClientViewModelFactory(private val repository: ClientRepository) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(ClientViewModel::class.java)) {
+            @Suppress("UNCHECKED_CAST")
+            return ClientViewModel(repository) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class: ${modelClass.name}")
+    }
+}

--- a/app/src/main/java/com/example/ordermanagementcake/ui/clients/ClientsListScreen.kt
+++ b/app/src/main/java/com/example/ordermanagementcake/ui/clients/ClientsListScreen.kt
@@ -1,236 +1,163 @@
 package com.example.ordermanagementcake.ui.clients
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
-import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.Search
-import androidx.compose.material3.Card
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.FabPosition
-import androidx.compose.material3.FloatingActionButton
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
-import androidx.compose.material3.TextFieldDefaults
-import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.TopAppBarDefaults
-import androidx.compose.material3.TopAppBarDefaults.windowInsets
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.navigation.NavHostController
-import androidx.navigation.compose.currentBackStackEntryAsState
-import androidx.navigation.compose.rememberNavController
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.ordermanagementcake.R
-import com.example.ordermanagementcake.ui.components.BottomNavigationBar
-import com.example.ordermanagementcake.ui.navigation.Routes
+import com.example.ordermanagementcake.data.local.OrderDatabase
+import com.example.ordermanagementcake.data.repository.ClientRepository
 
-
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun ClientsListScreen(){
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(16.dp)
-        ) {
-           // search bar
-            var searchText by remember { mutableStateOf("") }
-
-            OutlinedTextField(
-                value = searchText,
-                onValueChange = {searchText = it},
-                placeholder = {Text(
-                    text =  stringResource(id = R.string.search_clients),
-                    modifier = Modifier
-                        .padding(0.dp),
-                    textAlign = TextAlign.Center
-                )},
-                leadingIcon = {
-                    Icon(
-                        imageVector = Icons.Default.Search,
-                        contentDescription = "Search"
-                    )
-                },
-                colors = TextFieldDefaults.colors(
-                    focusedIndicatorColor = Color.Transparent,
-                    unfocusedIndicatorColor = Color.Transparent
-                ),
-                modifier = Modifier
-                    .width(400.dp)
+fun ClientsListScreen(
+    viewModel: ClientViewModel = viewModel(
+        factory = ClientViewModelFactory(
+            ClientRepository(
+                OrderDatabase.getInstance(LocalContext.current).clientDao()
             )
+        )
+    )
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
-            Spacer(modifier = Modifier.height(30.dp))
-
-            Text(
-                text = stringResource(id = R.string.directory_clients),
-                fontSize = 13.sp,
-                fontWeight = FontWeight.Bold
-            )
-            Row(
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                Text(
-                    text = stringResource(id = R.string.loyal_patrons),
-                    fontSize = 30.sp,
-                    fontWeight = FontWeight.ExtraBold
-                )
-
-                Spacer(modifier = Modifier.width(70.dp))
-
-                Text(
-                    text = stringResource(id = R.string.total_patrons),
-                    textAlign = TextAlign.Center,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(top = 7.dp)
-                )
-            }
-
-            LazyColumn(
-                modifier = Modifier.fillMaxSize()
-            ) {
-                item {
-                    Card(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(8.dp)
-                    ) {
-                        Row(
-                            verticalAlignment = Alignment.CenterVertically,
-                            modifier = Modifier.padding(12.dp)
-                        ) {
-                            Image(
-                                painter = painterResource(id = R.drawable.foto_profile),
-                                contentDescription = "Foto Profile",
-                                contentScale = ContentScale.Crop,
-                                modifier = Modifier
-                                    .size(60.dp)
-                                    .clip(CircleShape)
-
-                            )
-
-                            Spacer(modifier = Modifier.width(16.dp))
-                            Column(
-                                modifier = Modifier.weight(1f)
-                            ) {
-                                Text(
-                                    text = stringResource(id = R.string.client1_name),
-                                    fontSize = 16.sp,
-                                    fontWeight = FontWeight.Bold,
-                                    modifier = Modifier
-                                        .padding(bottom = 0.dp)
-                                )
-                                Text(
-                                    text = stringResource(id = R.string.nu_telefone1),
-                                    fontSize = 16.sp
-                                )
-                            }
-                            IconButton(
-                                onClick = { /* asaun icon bele klik */ }
-                            ) {
-                                Icon(
-                                    imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
-                                    contentDescription = "hmmm",
-                                    tint = Color.Gray
-                                )
-                            }
-                        }
-                    }
-
-                    Spacer(modifier = Modifier.width(16.dp))
-                }
-
-                item {
-                    Card(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(8.dp)
-                    ) {
-                        Row(
-                            verticalAlignment = Alignment.CenterVertically,
-                            modifier = Modifier.padding(12.dp)
-                        ) {
-                            Image(
-                                painter = painterResource(id = R.drawable.foto_profile),
-                                contentDescription = "Foto Profile",
-                                contentScale = ContentScale.Crop,
-                                modifier = Modifier
-                                    .size(60.dp)
-                                    .clip(CircleShape)
-
-                            )
-
-                            Spacer(modifier = Modifier.width(16.dp))
-                            Column(
-                                modifier = Modifier.weight(1f)
-                            ) {
-                                Text(
-                                    text = stringResource(id = R.string.client2_name),
-                                    fontSize = 16.sp,
-                                    fontWeight = FontWeight.Bold,
-                                    modifier = Modifier
-                                        .padding(bottom = 0.dp)
-                                )
-                                Text(
-                                    text = stringResource(id = R.string.nu_telefone2),
-                                    fontSize = 16.sp
-                                )
-                            }
-                            IconButton(
-                                onClick = { /* asaun icon bele klik */ }
-                            ) {
-                                Icon(
-                                    imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
-                                    contentDescription = "hmmm",
-                                    tint = Color.Gray
-                                )
-                            }
-                        }
-                    }
-                }
-            }
-
+    // Filter clients locally using the search query
+    val filteredClients = remember(uiState.clients, uiState.searchQuery) {
+        if (uiState.searchQuery.isBlank()) uiState.clients
+        else uiState.clients.filter {
+            it.name.contains(uiState.searchQuery, ignoreCase = true) ||
+                    it.phoneNumber.contains(uiState.searchQuery, ignoreCase = true)
         }
     }
 
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        OutlinedTextField(
+            value = uiState.searchQuery,
+            onValueChange = { viewModel.onSearchQueryChange(it) },
+            placeholder = {
+                Text(
+                    text = "buka client liu husi naran ka telefone...",
+                    textAlign = TextAlign.Start
+                )
+            },
+            leadingIcon = { Icon(Icons.Default.Search, contentDescription = "Search") },
+            colors = TextFieldDefaults.colors(
+                focusedIndicatorColor = Color.Transparent,
+                unfocusedIndicatorColor = Color.Transparent
+            ),
+            modifier = Modifier.fillMaxWidth()
+        )
 
-/*
+        Spacer(modifier = Modifier.height(24.dp))
 
-@Preview(showBackground = true)
-@Composable
-fun ClientsListScreenPreview(){
-    _root_ide_package_.com.example.ordermanagementcake.ui.theme.OrderManagementCakeTheme {
-        ClientsListScreen(navController = rememberNavController())
+        Text(
+            text = "Lista",
+            fontSize = 13.sp,
+            fontWeight = FontWeight.Bold
+        )
+        Row(modifier = Modifier.fillMaxWidth()) {
+            Text(
+                text = "Kliente fiel sira",
+                fontSize = 30.sp,
+                fontWeight = FontWeight.ExtraBold
+            )
+            Text(
+                text = "total ${filteredClients.size}",
+                textAlign = TextAlign.Center,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 7.dp)
+            )
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        when {
+            uiState.isLoading -> {
+                Box(modifier = Modifier.fillMaxWidth().padding(32.dp), contentAlignment = Alignment.Center) {
+                    CircularProgressIndicator()
+                }
+            }
+            uiState.errorMessage != null -> {
+                Text(
+                    text = "Error: ${uiState.errorMessage}",
+                    color = Color.Red,
+                    modifier = Modifier.padding(16.dp)
+                )
+            }
+            filteredClients.isEmpty() -> {
+                Text(
+                    text = "La iha kliente ne'ebé hetan.",
+                    modifier = Modifier.padding(16.dp),
+                    color = Color.Gray
+                )
+            }
+            else -> {
+                LazyColumn(modifier = Modifier.fillMaxSize()) {
+                    items(filteredClients, key = { it.id }) { client ->
+                        Card(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(vertical = 6.dp)
+                        ) {
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                modifier = Modifier.padding(12.dp)
+                            ) {
+                                Image(
+                                    painter = painterResource(id = R.drawable.foto_profile),
+                                    contentDescription = "Foto Profile",
+                                    contentScale = ContentScale.Crop,
+                                    modifier = Modifier
+                                        .size(60.dp)
+                                        .clip(CircleShape)
+                                )
+                                Spacer(modifier = Modifier.width(16.dp))
+                                Column(modifier = Modifier.weight(1f)) {
+                                    Text(
+                                        text = client.name,
+                                        fontSize = 16.sp,
+                                        fontWeight = FontWeight.Bold
+                                    )
+                                    Text(
+                                        text = client.phoneNumber,
+                                        fontSize = 16.sp
+                                    )
+                                }
+                                IconButton(onClick = { /* navigate to client detail */ }) {
+                                    Icon(
+                                        imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                                        contentDescription = "View client",
+                                        tint = Color.Gray
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
-}*/
+}

--- a/app/src/main/java/com/example/ordermanagementcake/ui/orders/OrderListScreen.kt
+++ b/app/src/main/java/com/example/ordermanagementcake/ui/orders/OrderListScreen.kt
@@ -1,254 +1,191 @@
 package com.example.ordermanagementcake.ui.orders
 
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
-import androidx.compose.foundation.horizontalScroll
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
-import com.example.ordermanagementcake.R
-import androidx.compose.runtime.*
-import androidx.compose.material3.*
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Search
-import androidx.compose.ui.graphics.Color
-import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.Button
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.Menu
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.tooling.preview.Preview
-import androidx.navigation.NavHostController
-import androidx.navigation.compose.currentBackStackEntryAsState
-import com.example.ordermanagementcake.ui.components.BottomNavigationBar
-import com.example.ordermanagementcake.ui.navigation.Routes
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.ordermanagementcake.R
+import com.example.ordermanagementcake.data.local.OrderDatabase
+import com.example.ordermanagementcake.data.repository.OrderRepository
+import androidx.compose.foundation.Image
 
-
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun OrderListScreen(){
-        Column(
+fun OrderListScreen(
+    viewModel: OrderViewModel = viewModel(
+        factory = OrderViewModelFactory(
+            OrderRepository(
+                OrderDatabase.getInstance(LocalContext.current).orderDao()
+            )
+        )
+    )
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    val statusFilters = listOf("PENDING", "IN_PROGRESS", "READY", "COMPLETED")
+    val statusLabels  = listOf("Hotu", "Hein", "Prosesu", "Prontu")
+
+    var searchText by remember { mutableStateOf("") }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+    ) {
+        Text(
+            text = "Order sira iha agora",
+            fontWeight = FontWeight.ExtraBold,
+            fontSize = 25.sp,
+            modifier = Modifier.padding(top = 16.dp, start = 15.dp)
+        )
+        Text(
+            text = "Jestiona ita-nia kriasaun kulinária",
+            modifier = Modifier.padding(bottom = 7.dp, start = 15.dp)
+        )
+
+        OutlinedTextField(
+            value = searchText,
+            onValueChange = { searchText = it },
+            label = { Text("buka order...") },
+            leadingIcon = { Icon(Icons.Default.Search, contentDescription = "Search") },
+            colors = TextFieldDefaults.colors(
+                focusedIndicatorColor = Color.Transparent,
+                unfocusedIndicatorColor = Color.Transparent
+            ),
             modifier = Modifier
-                .fillMaxSize()
-                .verticalScroll(rememberScrollState())
+                .fillMaxWidth()
+                .padding(horizontal = 10.dp)
+        )
+
+        // Filter buttons
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 16.dp, start = 15.dp)
+                .horizontalScroll(rememberScrollState())
         ) {
-            Text(
-                text = stringResource(id = R.string.current_order),
-                fontWeight = FontWeight.ExtraBold,
-                fontSize = 25.sp,
-                modifier = Modifier
-                    .padding(top = 16.dp, start = 15.dp)
-
-            )
-            Text(
-                text = stringResource(id = R.string.culinary_cration),
-                modifier = Modifier
-                    .padding(bottom = 7.dp, start = 15.dp)
-            )
-
-            // search bar
-            var searchText by remember { mutableStateOf("") }
-
-            OutlinedTextField(
-                value = searchText,
-                onValueChange = {searchText = it},
-                label = {Text(
-                    text =  stringResource(id = R.string.search_order),
-                    modifier = Modifier.padding(all = 0.dp)
-                )},
-                leadingIcon = {
-                    Icon(
-                        imageVector = Icons.Default.Search,
-                        contentDescription = "Search"
-                    )
-                },
-                colors = TextFieldDefaults.colors(
-                    focusedIndicatorColor = Color.Transparent,
-                    unfocusedIndicatorColor = Color.Transparent
-                ),
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(end = 10.dp, start = 10.dp)
-            )
-
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(top = 16.dp, start = 15.dp)
-                    .horizontalScroll(rememberScrollState())
-            ) {
+            statusFilters.forEachIndexed { index, status ->
+                val isSelected = uiState.selectedStatus == status
                 Button(
-                    onClick = {},
-                    modifier = Modifier
-                        .padding(12.dp),
+                    onClick = { viewModel.loadOrders(status) },
+                    modifier = Modifier.padding(horizontal = 6.dp),
                     colors = ButtonDefaults.buttonColors(
-                        containerColor = Color(0xFFF87146),
+                        containerColor = if (isSelected) Color(0xFFF87146) else Color.Gray,
                         contentColor = Color.White
                     )
                 ) {
-                    Text(
-                        text = stringResource(id = R.string.btn_all_order)
-                    )
-                }
-
-                Button(
-                    onClick = {},
-                    modifier = Modifier
-                        .padding(12.dp),
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = Color.Gray,
-                        contentColor = Color.White
-                    )
-                ) {
-                    Text(
-                        text = stringResource(id = R.string.btn_pending_order)
-                    )
-
-                }
-
-                Button(
-                    onClick = {},
-                    modifier = Modifier
-                        .padding(12.dp),
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = Color.Gray,
-                        contentColor = Color.White
-                    )
-                ) {
-                    Text(
-                        text = stringResource(id = R.string.btn_inprogress_order)
-                    )
-
-                }
-
-                Button(
-                    onClick = {},
-                    modifier = Modifier
-                        .padding(12.dp),
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = Color.Gray,
-                        contentColor = Color.White
-                    )
-                ) {
-                    Text(
-                        text = stringResource(id = R.string.btn_ready_order)
-                    )
-
-                }
-                Button(
-                    onClick = {},
-                    modifier = Modifier
-                        .padding(12.dp),
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = Color.Gray,
-                        contentColor = Color.White
-                    )
-                ) {
-                    Text(
-                        text = stringResource(id = R.string.btn_complete)
-                    )
-
+                    Text(statusLabels[index])
                 }
             }
-            Card(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(16.dp)
-            ) {
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(16.dp)
-                ) {
-                    Image(
-                        painter = painterResource(id = R.drawable.double_chodolate_fudge),
-                        contentDescription = "Foto Profile",
-                        contentScale = ContentScale.Crop,
-                        modifier = Modifier
-                            .size(70.dp)
-                            .clip(CircleShape)
-                    )
-                    Column(
-                        modifier = Modifier
-                            .padding(start = 10.dp)
-                            .weight(1f) // ida ne'e atu nun'ee elementu sira pas pas
-                    ) {
-                        Text(
-                            text = stringResource(id = R.string.naran1_order),
-                            fontWeight = FontWeight.Bold,
-                            fontSize = 17.sp,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis
-                        )
-                        Text(
-                            text = stringResource(id = R.string.cake1_type),
-                            fontSize = 15.sp,
-                            maxLines = 2,
-                            overflow = TextOverflow.Ellipsis
-                        )
-                    }
-                    Column(
-                        horizontalAlignment = Alignment.End // allgiht data ba iah liman loos
-                    ) {
-                        Text(
-                            text = stringResource(id = R.string.pickup1),
-                            fontSize = 15.sp,
-                        )
-                        Text(
-                            text = stringResource(id = R.string.time_pickup1),
-                            fontSize = 11.sp,
-                            fontWeight = FontWeight.Bold,
-                        )
-                    }
-                }
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(end = 10.dp, bottom = 10.dp),
-                    horizontalArrangement = Arrangement.End
-                ) {
-                    Button(
-                        onClick = {},
-                        modifier = Modifier.height(35.dp),
-                        colors = ButtonDefaults.buttonColors(
-                            containerColor = Color(0xFFEE8111),
-                            contentColor = Color.White
-                        )
-                    ) {
-                        Text(
-                            text = stringResource(id = R.string.btn_pending_order),
-                            fontSize = 10.sp
-                        )
-                    }
-                }
-            }
-
-
-
         }
 
-    }
-
-
-@Preview(showBackground = true)
-@Composable
-fun OrderListScreenPreview(){
-    _root_ide_package_.com.example.ordermanagementcake.ui.theme.OrderManagementCakeTheme {
-        OrderListScreen()
+        // Loading / error / list
+        when {
+            uiState.isLoading -> {
+                Box(modifier = Modifier.fillMaxWidth().padding(32.dp), contentAlignment = Alignment.Center) {
+                    CircularProgressIndicator()
+                }
+            }
+            uiState.errorMessage != null -> {
+                Text(
+                    text = "Error: ${uiState.errorMessage}",
+                    color = Color.Red,
+                    modifier = Modifier.padding(16.dp)
+                )
+            }
+            uiState.orders.isEmpty() -> {
+                Text(
+                    text = "La iha order ba status ne'e.",
+                    modifier = Modifier.padding(16.dp),
+                    color = Color.Gray
+                )
+            }
+            else -> {
+                uiState.orders.forEach { order ->
+                    Card(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(16.dp)
+                    ) {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(16.dp)
+                        ) {
+                            Image(
+                                painter = painterResource(id = R.drawable.double_chodolate_fudge),
+                                contentDescription = "Order image",
+                                contentScale = ContentScale.Crop,
+                                modifier = Modifier
+                                    .size(70.dp)
+                                    .clip(CircleShape)
+                            )
+                            Column(
+                                modifier = Modifier
+                                    .padding(start = 10.dp)
+                                    .weight(1f)
+                            ) {
+                                Text(
+                                    text = "Order #${order.id}",
+                                    fontWeight = FontWeight.Bold,
+                                    fontSize = 17.sp,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis
+                                )
+                                Text(
+                                    text = order.notes.ifBlank { "La iha nota" },
+                                    fontSize = 15.sp,
+                                    maxLines = 2,
+                                    overflow = TextOverflow.Ellipsis
+                                )
+                            }
+                            Column(horizontalAlignment = Alignment.End) {
+                                Text(text = "Foti", fontSize = 15.sp)
+                                Text(
+                                    text = order.pickupDate,
+                                    fontSize = 11.sp,
+                                    fontWeight = FontWeight.Bold
+                                )
+                            }
+                        }
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(end = 10.dp, bottom = 10.dp),
+                            horizontalArrangement = Arrangement.End
+                        ) {
+                            Button(
+                                onClick = { viewModel.updateStatus(order.id, "IN_PROGRESS") },
+                                modifier = Modifier.height(35.dp),
+                                colors = ButtonDefaults.buttonColors(
+                                    containerColor = Color(0xFFEE8111),
+                                    contentColor = Color.White
+                                )
+                            ) {
+                                Text(text = order.status, fontSize = 10.sp)
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/app/src/main/java/com/example/ordermanagementcake/ui/orders/OrderUiState.kt
+++ b/app/src/main/java/com/example/ordermanagementcake/ui/orders/OrderUiState.kt
@@ -1,0 +1,10 @@
+package com.example.ordermanagementcake.ui.orders
+
+import com.example.ordermanagementcake.data.local.entities.OrderEntity
+
+data class OrderUiState (
+    val orders: List<OrderEntity> = emptyList(),
+    val isLoading: Boolean = true,
+    val errorMessage: String? = null,
+    val selectedStatus: String = "PENDING"
+)

--- a/app/src/main/java/com/example/ordermanagementcake/ui/orders/OrderViewModel.kt
+++ b/app/src/main/java/com/example/ordermanagementcake/ui/orders/OrderViewModel.kt
@@ -1,0 +1,52 @@
+package com.example.ordermanagementcake.ui.orders
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.ordermanagementcake.data.local.entities.OrderEntity
+import com.example.ordermanagementcake.data.repository.OrderRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+class OrderViewModel(private val repository: OrderRepository) : ViewModel() {
+    private val _uiState = MutableStateFlow(OrderUiState())
+    val uiState: StateFlow<OrderUiState> = _uiState.asStateFlow()
+
+    init {
+        loadOrders("PENDING")
+    }
+
+    fun loadOrders(status: String) {
+        _uiState.update { it.copy(isLoading = true, selectedStatus = status, errorMessage = null) }
+        viewModelScope.launch {
+            repository.getOrdersByStatus(status)
+                .catch { e ->
+                    _uiState.update { it.copy(isLoading = false, errorMessage = e.message) }
+                }
+                .collect { orders ->
+                    _uiState.update { it.copy(orders = orders, isLoading = false) }
+                }
+        }
+    }
+
+    fun updateStatus(orderId: Int, status: String) {
+        viewModelScope.launch { // ne haranarn coroutin jadi nia run iha background  hodi update staus via repoisitry
+            repository.updateStatus(orderId, status)
+        }
+    }
+
+    fun deleteOrder(order: OrderEntity) {
+        viewModelScope.launch {
+            repository.deleteOrder(order)
+        }
+    }
+
+    fun insertOrder(order: OrderEntity) {
+        viewModelScope.launch {
+            repository.insertOrder(order)
+        }
+    }
+}

--- a/app/src/main/java/com/example/ordermanagementcake/ui/orders/OrderViewModelFactory.kt
+++ b/app/src/main/java/com/example/ordermanagementcake/ui/orders/OrderViewModelFactory.kt
@@ -1,0 +1,16 @@
+package com.example.ordermanagementcake.ui.orders
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.example.ordermanagementcake.data.repository.OrderRepository
+
+// ida nee'e aty create ViewModel
+class OrderViewModelFactory(private val repository: OrderRepository) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(OrderViewModel::class.java)) {
+            @Suppress("UNCHECKED_CAST")
+            return OrderViewModel(repository) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class: ${modelClass.name}")
+    }
+}


### PR DESCRIPTION
## Sumario

PR ida ne'e connect `data/` layer (Room, Dao, Entities) ba iha **UI** liu husi **ViewMOdel**

---

## Saida mak muda

### File Foun Sira
- `data/repository/OrderRepository.kt` — abstracts `OrderDao` from the ViewModel
- `data/repository/ClientRepository.kt` — abstracts `ClientDao` from the ViewModel
- `data/local/SeedData.kt` — prepopulates the database with example data on first install
- `ui/orders/OrderUiState.kt` — data class holding the UI state for the orders screen
- `ui/orders/OrderViewModel.kt` — manages order state, exposes `StateFlow<OrderUiState>`
- `ui/orders/OrderViewModelFactory.kt` — manual factory to inject `OrderRepository`
- `ui/clients/ClientUiState.kt` — data class holding the UI state for the clients screen
- `ui/clients/ClientViewModel.kt` — manages client state, exposes `StateFlow<ClientUiState>`
- `ui/clients/ClientViewModelFactory.kt` — manual factory to inject `ClientRepository`

### File ne'ebe mak modifika
- `data/local/OrderDatabase.kt` — added `PrepopulateCallback` to trigger `seedDatabase()` on first database creation
- `ui/orders/OrderListScreen.kt` — replaced hardcoded string resources with live data from `OrderViewModel`; added loading, error, and empty states; filter buttons now call `viewModel.loadOrders(status)`
- `ui/clients/ClientsListScreen.kt` — replaced two hardcoded `item{}` blocks with a dynamic `items()` loop over real `ClientEntity` rows; search now filters live data; removed duplicate `Scaffold`, `TopBar`, `BottomBar`, and `FAB` since these are already provided by `AppNavHost`

---

## Oinsa data Flow
```
SeedData (first launch)
  → Room / SQLite
    → DAO returns Flow<List<...>>
      → Repository passes Flow through
        → ViewModel collects Flow → updates StateFlow<UiState>
          → Screen observes via collectAsStateWithLifecycle()
            → Compose recomposes with real data
```