### PR TITLE
feat: Add delete confirmation dialogs for Clients

### DIFF
--- a/app/src/main/java/com/example/ordermanagementcake/ui/clients/ClientDetailScreen.kt
+++ b/app/src/main/java/com/example/ordermanagementcake/ui/clients/ClientDetailScreen.kt
@@ -170,7 +170,7 @@ fun ClientInfoCard(
     phone: String,
     address: String,
     notes: String,
-    onEditClick: () -> Unit
+    onEditClick: () -> Unit,
 ) {
     Card(
         modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/com/example/ordermanagementcake/ui/clients/ClientsListScreen.kt
+++ b/app/src/main/java/com/example/ordermanagementcake/ui/clients/ClientsListScreen.kt
@@ -39,6 +39,7 @@ fun ClientsListScreen(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val context = LocalContext.current
 
+
     val filteredClients = remember(uiState.clients, uiState.searchQuery) {
         if (uiState.searchQuery.isBlank()) uiState.clients
         else uiState.clients.filter {
@@ -168,6 +169,9 @@ fun ClientCard(
     onEdit: () -> Unit,
     onDelete: () -> Unit
 ) {
+
+    var showDeleteConfirm by remember { mutableStateOf(false) }
+
     Card(
         onClick = onClick,
         modifier = Modifier.fillMaxWidth(),
@@ -258,12 +262,29 @@ fun ClientCard(
                         text = { Text("Delete") },
                         leadingIcon = { Icon(Icons.Default.Delete, contentDescription = null) },
                         onClick = {
-                            onDelete()
+                            showDeleteConfirm = true
                             expanded = false
                         }
                     )
                 }
             }
         }
+
+    }
+    if (showDeleteConfirm) {
+        AlertDialog(
+            onDismissRequest = { showDeleteConfirm = false },
+            title = { Text("Konfirma Delete") },
+            text = { Text("Ita boot hakarak delete kliente \"${client.name}\"?") },
+            confirmButton = {
+                TextButton(onClick = {
+                    onDelete()              // ← parent's callback, fires only after confirm
+                    showDeleteConfirm = false
+                }) { Text("Delete", color = Color.Red) }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDeleteConfirm = false }) { Text("Kansela") }
+            }
+        )
     }
 }

--- a/app/src/main/java/com/example/ordermanagementcake/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/example/ordermanagementcake/ui/navigation/NavGraph.kt
@@ -15,6 +15,7 @@ import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.PersonAdd
 import androidx.compose.material.icons.filled.Phone
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.HorizontalDivider
@@ -24,6 +25,7 @@ import androidx.compose.material3.ModalNavigationDrawer
 import androidx.compose.material3.NavigationDrawerItem
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
@@ -131,11 +133,42 @@ fun AppNavHost(
                         onMenuClick = { scope.launch { drawerState.open() } }
                     )
                 } else if (currentRoute?.startsWith("client_detail/") == true) {
+                    val clientUiState by clientViewModel.uiState.collectAsStateWithLifecycle()
+                    var showDeleteDialog by remember { mutableStateOf(false) }
+
                     AppTopBarDelete(
                         title = "Detalhu Kliente",
                         onBackClick = { navController.popBackStack() },
-                        onDeleteClick = { /* Logic for deletion to be handled later */ }
+                        onDeleteClick = { showDeleteDialog = true }
                     )
+
+                    if (showDeleteDialog) {
+                        AlertDialog(
+                            onDismissRequest = { showDeleteDialog = false },
+                            title = { Text("Konfirma Delete") },
+                            text = {
+                                Text(
+                                    "Ita boot hakarak delete kliente \"${clientUiState.selectedClient?.client?.name}\"?"
+                                )
+                            },
+                            confirmButton = {
+                                TextButton(onClick = {
+                                    clientUiState.selectedClient?.client?.let { client ->
+                                        clientViewModel.deleteClient(client)
+                                        navController.popBackStack()
+                                    }
+                                    showDeleteDialog = false
+                                }) {
+                                    Text("Delete", color = Color.Red)
+                                }
+                            },
+                            dismissButton = {
+                                TextButton(onClick = { showDeleteDialog = false }) {
+                                    Text("Kansela")
+                                }
+                            }
+                        )
+                    }
                 }
             },
             bottomBar = {


### PR DESCRIPTION
## Description
This PR improves the user experience by adding confirmation dialogs before deleting a client. This prevents accidental deletions from both the client list and the client detail screens.

## Changes Made
- **ClientsListScreen**: Added an `AlertDialog` that appears when the user selects "Delete" from the client card menu.
- **NavGraph (Client Detail)**: Implemented deletion logic and a confirmation dialog in the `AppTopBarDelete` for the client detail screen. When confirmed, the client is deleted via the `ClientViewModel` and the app navigates back to the list.
- **ClientDetailScreen**: Minor formatting update.

## Impact
- Users are now prompted to confirm their intent before a client is permanently removed from the database.
- Enhanced safety and better UX for data management.