### PR TITLE
refactor: integrate NewTierForm as a modal sheet in NewCakeForm

### DIFF
--- a/app/src/main/java/com/example/ordermanagementcake/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/example/ordermanagementcake/ui/navigation/NavGraph.kt
@@ -69,7 +69,6 @@ object Routes {
     const val NEW_CLIENT = "new_client"
     const val DETAIL_CLIENT = "client_detail/{clientID}" // route based on
     const val NEW_CAKE = "new_cake"
-    const val NEW_TIER = "new_tier"
 
     fun clientDetail(clientId: Int) = "client_detail/$clientId"
 
@@ -325,14 +324,24 @@ fun AppNavHost(
                         }
                     )
                 }
-                composable (route = Routes.NEW_CAKE)  {
-                    NewCakeForm (
-                        onAddTier = { navController.navigate(Routes.NEW_TIER)}
-                    ) {  }
-                }
+                composable(route = Routes.NEW_CAKE) {
+                    var showTierSheet by remember { mutableStateOf(false) }
 
-                composable(route = Routes.NEW_TIER) {
-                    NewTierForm {  }
+                    NewCakeForm(
+                        onAddTier = { showTierSheet = true },
+                        onSaveCake = { /* Saving logic */ },
+                        onAddReference = { /* Reference Action */ }
+                    )
+
+                    if (showTierSheet) {
+                        NewTierForm(
+                            onDismiss = { showTierSheet = false },
+                            onSave = { tiersState ->
+                                // Process the tier specifications here
+                                showTierSheet = false
+                            }
+                        )
+                    }
                 }
             }
         }


### PR DESCRIPTION
This PR refactors the cake creation flow to improve user experience by integrating the tier addition process directly into the cake form.

**Changes:**
- **Navigation:** Removed the dedicated `NEW_TIER` route as it is no longer needed as a separate screen.
- **UI Logic:** Updated `NavGraph.kt` to handle the `NewTierForm` as a modal sheet within the `NewCakeForm` destination.
- **State Management:** Introduced a local `showTierSheet` state in the `NEW_CAKE` composable to toggle the visibility of the tier form.
- **Form Integration:** `NewCakeForm` now triggers the tier sheet instead of navigating away, allowing for a more seamless data entry process.

Fixes: #126 