### PR TITLE
fix: increase bottom padding to prevent FAB overlap

### DIFF
--- a/app/src/main/java/com/example/ordermanagementcake/ui/clients/ClientsListScreen.kt
+++ b/app/src/main/java/com/example/ordermanagementcake/ui/clients/ClientsListScreen.kt
@@ -142,7 +142,7 @@ fun ClientsListScreen(
                 else -> {
                     LazyColumn(
                         modifier = Modifier.fillMaxSize(),
-                        contentPadding = PaddingValues(bottom = 16.dp),
+                        contentPadding = PaddingValues(bottom = 88.dp),
                         verticalArrangement = Arrangement.spacedBy(10.dp)
                     ) {
                         items(filteredClients, key = { it.id }) { client ->

--- a/app/src/main/java/com/example/ordermanagementcake/ui/orders/OrderListScreen.kt
+++ b/app/src/main/java/com/example/ordermanagementcake/ui/orders/OrderListScreen.kt
@@ -80,9 +80,8 @@ fun OrderListScreen(viewModel: OrderViewModel) {
     var searchText by remember { mutableStateOf("") }
 
     LazyColumn(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(bottom = 16.dp)
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(bottom = 88.dp)
     ) {
         // Header
         item {


### PR DESCRIPTION
This PR increases the bottom padding in `ClientsListScreen` and `OrderListScreen` to ensure that the content is not obscured by the Floating Action Button (FAB).

## ScreenShot
<img width="300" alt="screenshot_2026-05-28_13-26-58" src="https://github.com/user-attachments/assets/449fea33-d834-4c80-b994-701f14ef8212" />
<img width="300"  alt="screenshot_2026-05-28_13-27-06" src="https://github.com/user-attachments/assets/5ee4bc18-58c4-440c-bb9f-3cde2a40934f" />


Fixes: #89