### PR TITLE
feat(Tier): Add tier level deletion and fix client list imports

### DIFF
--- a/app/src/main/java/com/example/ordermanagementcake/ui/clients/ClientsListScreen.kt
+++ b/app/src/main/java/com/example/ordermanagementcake/ui/clients/ClientsListScreen.kt
@@ -22,6 +22,9 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import android.widget.Toast
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 import androidx.compose.material.icons.Icons
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel

--- a/app/src/main/java/com/example/ordermanagementcake/ui/forms/tier/NewTierForm.kt
+++ b/app/src/main/java/com/example/ordermanagementcake/ui/forms/tier/NewTierForm.kt
@@ -209,6 +209,8 @@ fun NewTierForm(
                         tierNumber = level,
                         isSelected = activeTierLevel == level,
                         onClick = { activeTierLevel = level },
+                        onDelete = { /* To be implemented in next step */ },
+                        showDelete = tiersState.size > 1,
                         modifier = Modifier.width(65.dp)
                     )
                 }
@@ -795,26 +797,51 @@ fun TierSelectionButton(
     tierNumber: Int,
     isSelected: Boolean,
     onClick: () -> Unit,
+    onDelete: () -> Unit,
+    showDelete: Boolean,
     modifier: Modifier = Modifier
 ) {
-    Surface(
-        modifier = modifier
-            .height(56.dp)
-            .clickable { onClick() },
-        shape = RoundedCornerShape(16.dp),
-        color = if (isSelected) MaterialTheme.colorScheme.primaryContainer else Color.Transparent,
-        border = androidx.compose.foundation.BorderStroke(
-            width = if (isSelected) 2.dp else 1.dp,
-            color = if (isSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outlineVariant
-        )
-    ) {
-        Box(contentAlignment = Alignment.Center) {
-            Text(
-                text = tierNumber.toString(),
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.Bold,
-                color = if (isSelected) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurfaceVariant
+    Box(modifier = modifier.padding(top = 4.dp, end = 4.dp)) {
+        Surface(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(56.dp)
+                .clickable { onClick() },
+            shape = RoundedCornerShape(16.dp),
+            color = if (isSelected) MaterialTheme.colorScheme.primaryContainer else Color.Transparent,
+            border = androidx.compose.foundation.BorderStroke(
+                width = if (isSelected) 2.dp else 1.dp,
+                color = if (isSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outlineVariant
             )
+        ) {
+            Box(contentAlignment = Alignment.Center) {
+                Text(
+                    text = tierNumber.toString(),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = if (isSelected) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+
+        if (showDelete) {
+            Surface(
+                onClick = onDelete,
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .offset(x = 6.dp, y = (-6).dp)
+                    .size(20.dp),
+                shape = CircleShape,
+                color = MaterialTheme.colorScheme.error,
+                tonalElevation = 4.dp
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Close,
+                    contentDescription = "Hamoos Nívél",
+                    modifier = Modifier.padding(4.dp),
+                    tint = MaterialTheme.colorScheme.onError
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/ordermanagementcake/ui/forms/tier/NewTierForm.kt
+++ b/app/src/main/java/com/example/ordermanagementcake/ui/forms/tier/NewTierForm.kt
@@ -209,7 +209,26 @@ fun NewTierForm(
                         tierNumber = level,
                         isSelected = activeTierLevel == level,
                         onClick = { activeTierLevel = level },
-                        onDelete = { /* To be implemented in next step */ },
+                        onDelete = {
+                            if (tiersState.size > 1) {
+                                // 1. Calculate the new level to focus on BEFORE removing
+                                if (activeTierLevel == level) {
+                                    val sortedKeys = tiersState.keys.toList().sorted()
+                                    val currentIndex = sortedKeys.indexOf(level)
+                                    
+                                    activeTierLevel = if (currentIndex > 0) {
+                                        // Focus on the one "below" it (the previous level)
+                                        sortedKeys[currentIndex - 1]
+                                    } else {
+                                        // If it was the first level, focus on the new first one
+                                        sortedKeys[1] 
+                                    }
+                                }
+                                
+                                // 2. Now safe to remove
+                                tiersState.remove(level)
+                            }
+                        },
                         showDelete = tiersState.size > 1,
                         modifier = Modifier.width(65.dp)
                     )


### PR DESCRIPTION
This PR adds the ability to delete tier levels in the NewTierForm and fixes missing imports in ClientsListScreen.kt.

### Changes:
- Added delete button to tier selection UI.
- Implemented deletion logic with smart pointer switching (focus moves to the level below when the current level is deleted).
- Fixed SimpleDateFormat, Locale, and Date imports in ClientsListScreen.kt.