### PR TITLE
Feat/image referenc

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -79,6 +79,9 @@ dependencies {
     // Navigation
     implementation("androidx.navigation:navigation-compose:2.8.3")
 
+    // Coil Image Loading
+    implementation(libs.coil.compose)
+
     // Testing
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/app/src/main/java/com/example/ordermanagementcake/data/util/ImageHelper.kt
+++ b/app/src/main/java/com/example/ordermanagementcake/data/util/ImageHelper.kt
@@ -1,0 +1,89 @@
+package com.example.ordermanagementcake.data.util
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.net.Uri
+import android.util.Log
+import java.io.File
+import java.io.FileOutputStream
+import java.util.UUID
+
+/**
+ * Utility class to handle image persistence by copying files to internal storage.
+ */
+object ImageHelper {
+    private const val TAG = "ImageHelper"
+    private const val FOLDER_NAME = "cake_images"
+
+    /**
+     * Copies an image from a URI (Gallery) to the app's internal private storage.
+     * Returns the absolute path of the saved file, or null if it fails.
+     */
+    fun saveImageToInternalStorage(context: Context, uri: Uri): String? {
+        return try {
+            val inputStream = context.contentResolver.openInputStream(uri) ?: return null
+            
+            val file = createInternalFile(context)
+            val outputStream = FileOutputStream(file)
+            
+            inputStream.use { input ->
+                outputStream.use { output ->
+                    input.copyTo(output)
+                }
+            }
+
+            Log.d(TAG, "Image saved successfully to: ${file.absolutePath}")
+            file.absolutePath
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to save image from URI", e)
+            null
+        }
+    }
+
+    /**
+     * Saves a Bitmap (Camera Preview) to the app's internal private storage.
+     */
+    fun saveBitmapToInternalStorage(context: Context, bitmap: Bitmap): String? {
+        return try {
+            val file = createInternalFile(context)
+            val outputStream = FileOutputStream(file)
+            
+            outputStream.use { output ->
+                bitmap.compress(Bitmap.CompressFormat.JPEG, 90, output)
+                output.flush()
+            }
+
+            Log.d(TAG, "Bitmap saved successfully to: ${file.absolutePath}")
+            file.absolutePath
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to save bitmap", e)
+            null
+        }
+    }
+
+    private fun createInternalFile(context: Context): File {
+        val folder = File(context.filesDir, FOLDER_NAME)
+        if (!folder.exists()) {
+            folder.mkdirs()
+        }
+        val fileName = "cake_${UUID.randomUUID()}.jpg"
+        return File(folder, fileName)
+    }
+
+    /**
+     * Optional: Deletes an image file if it's no longer needed.
+     */
+    fun deleteImage(path: String?): Boolean {
+        if (path == null) return false
+        return try {
+            val file = File(path)
+            if (file.exists()) {
+                file.delete()
+            } else {
+                false
+            }
+        } catch (e: Exception) {
+            false
+        }
+    }
+}

--- a/app/src/main/java/com/example/ordermanagementcake/ui/clients/ClientsListScreen.kt
+++ b/app/src/main/java/com/example/ordermanagementcake/ui/clients/ClientsListScreen.kt
@@ -30,6 +30,9 @@ import com.example.ordermanagementcake.data.repository.ClientRepository
 import com.example.ordermanagementcake.data.local.entities.ClientEntity
 import com.example.ordermanagementcake.ui.theme.extendedColors
 import kotlin.math.absoluteValue
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 
 @Composable
 fun ClientsListScreen(

--- a/app/src/main/java/com/example/ordermanagementcake/ui/forms/cakes/NewCakeForm.kt
+++ b/app/src/main/java/com/example/ordermanagementcake/ui/forms/cakes/NewCakeForm.kt
@@ -1,5 +1,8 @@
 package com.example.ordermanagementcake.ui.forms.cakes
 
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.activity.result.launch
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -25,18 +28,24 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.AddPhotoAlternate
 import androidx.compose.material.icons.filled.AutoFixHigh
 import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.PhotoCamera
+import androidx.compose.material.icons.filled.PhotoLibrary
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -52,6 +61,7 @@ import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -63,6 +73,7 @@ import com.example.ordermanagementcake.ui.theme.OrderManagementCakeTheme
 import com.example.ordermanagementcake.ui.theme.extendedColors
 
 // Main composable function for the Customize Cake screen
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun NewCakeForm(
     onSaveCake: (CakeDraft) -> Unit = {},
@@ -75,6 +86,73 @@ fun NewCakeForm(
     var imageUri by remember { mutableStateOf<String?>(null) }
     var tiers by remember { mutableStateOf(emptyList<TierDraft>()) }
     var showTierForm by remember { mutableStateOf(false) }
+    var showImageSourceDialog by remember { mutableStateOf(false) }
+    val sheetState = rememberModalBottomSheetState()
+
+    // Launcher ba Galeria
+    val galleryLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.GetContent()
+    ) { uri ->
+        if (uri != null) {
+            imageUri = uri.toString()
+            println("Image selected from gallery: $uri")
+        }
+    }
+
+    // Launcher ba camera nian
+    val cameraLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.TakePicturePreview()
+    ) { bitmap ->
+
+        // IF the camera taksea picture which make it not null
+        if (bitmap != null) {
+            println("Camera Opened and photo taken")
+        }
+    }
+
+    if (showImageSourceDialog) {
+        ModalBottomSheet(
+            onDismissRequest = { showImageSourceDialog = false },
+            sheetState = sheetState,
+            containerColor = MaterialTheme.colorScheme.surface,
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 32.dp, start = 24.dp, end = 24.dp, top = 8.dp)
+            ) {
+                Text(
+                    text = "Hili Fonte Imajen",
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    modifier = Modifier.padding(bottom = 24.dp)
+                )
+                
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceEvenly
+                ) {
+                    ImageSourceOption(
+                        icon = Icons.Default.PhotoCamera,
+                        label = "Kamera",
+                        onClick = {
+                            showImageSourceDialog = false
+                            cameraLauncher.launch()
+                        }
+                    )
+                    ImageSourceOption(
+                        icon = Icons.Default.PhotoLibrary,
+                        label = "Galeria",
+                        onClick = {
+                            showImageSourceDialog = false
+                            galleryLauncher.launch("image/*")
+                        }
+                    )
+                }
+            }
+        }
+    }
 
     val extendedColors = MaterialTheme.extendedColors
     
@@ -178,11 +256,10 @@ fun NewCakeForm(
 
             // Section for adding a Reference Image
             SectionCard(title = "IMAJEN REFERÉNSIA") {
-                DashedAddBox(
-                    icon = Icons.Default.AddPhotoAlternate,
-                    title = "AUMENTA IMAJEN REFERÉNSIA",
-                    description = "Muda foto husi dezeñu bolo ne'ebé Ita gosta",
-                    onClick = { /* Handle image selection */ }
+                ImageReferencePlaceholder(
+                    onClick = {
+                        showImageSourceDialog = true
+                    }
                 )
             }
 
@@ -257,6 +334,57 @@ fun NewCakeForm(
                 onSaveCake(CakeDraft(cakeTitle = cakeTitle, cakeNotes = cakeNotes, imageUri = imageUri, tiers = tiers))
             }
         )
+    }
+}
+
+@Composable
+fun ImageReferencePlaceholder(
+    onClick: () -> Unit
+) {
+    Surface(
+        onClick = onClick,
+        color = MaterialTheme.extendedColors.surfaceContainerLow,
+        shape = RoundedCornerShape(20.dp),
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Row(
+            modifier = Modifier
+                .padding(16.dp)
+                .fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(56.dp)
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(MaterialTheme.colorScheme.primaryContainer),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = Icons.Default.AddPhotoAlternate,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                    modifier = Modifier.size(28.dp)
+                )
+            }
+            
+            Spacer(modifier = Modifier.width(16.dp))
+            
+            Column {
+                Text(
+                    text = "Adisiona Imajen Referénsia",
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+                Spacer(modifier = Modifier.height(2.dp))
+                Text(
+                    text = "Hili husi galeria ka foti foto foun",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
     }
 }
 
@@ -485,6 +613,43 @@ fun BottomSummaryBar(
                 }
             }
         }
+    }
+}
+
+@Composable
+fun ImageSourceOption(
+    icon: ImageVector,
+    label: String,
+    onClick: () -> Unit
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier
+            .clip(RoundedCornerShape(16.dp))
+            .clickable { onClick() }
+            .padding(16.dp)
+    ) {
+        Surface(
+            modifier = Modifier.size(64.dp),
+            shape = CircleShape,
+            color = MaterialTheme.colorScheme.primaryContainer
+        ) {
+            Box(contentAlignment = Alignment.Center) {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                    modifier = Modifier.size(32.dp)
+                )
+            }
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelLarge,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurface
+        )
     }
 }
 

--- a/app/src/main/java/com/example/ordermanagementcake/ui/forms/cakes/NewCakeForm.kt
+++ b/app/src/main/java/com/example/ordermanagementcake/ui/forms/cakes/NewCakeForm.kt
@@ -57,15 +57,18 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import coil.compose.AsyncImage
 import com.example.ordermanagementcake.data.draft.CakeDraft
 import com.example.ordermanagementcake.data.draft.TierDraft
 import com.example.ordermanagementcake.data.util.ImageHelper
@@ -103,7 +106,7 @@ fun NewCakeForm(
                 println("Image saved to internal storage: $internalPath")
             }
         }
-    }3
+    }
 
     // Launcher ba camera nian
     val cameraLauncher = rememberLauncherForActivityResult(
@@ -265,6 +268,7 @@ fun NewCakeForm(
             // Section for adding a Reference Image
             SectionCard(title = "IMAJEN REFERÉNSIA") {
                 ImageReferencePlaceholder(
+                    imageUri = imageUri,
                     onClick = {
                         showImageSourceDialog = true
                     }
@@ -347,50 +351,85 @@ fun NewCakeForm(
 
 @Composable
 fun ImageReferencePlaceholder(
+    imageUri: String?,
     onClick: () -> Unit
 ) {
     Surface(
         onClick = onClick,
         color = MaterialTheme.extendedColors.surfaceContainerLow,
         shape = RoundedCornerShape(20.dp),
-        modifier = Modifier.fillMaxWidth()
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(if (imageUri != null) 200.dp else 88.dp) // Taller when showing image
     ) {
-        Row(
-            modifier = Modifier
-                .padding(16.dp)
-                .fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Box(
-                modifier = Modifier
-                    .size(56.dp)
-                    .clip(RoundedCornerShape(12.dp))
-                    .background(MaterialTheme.colorScheme.primaryContainer),
-                contentAlignment = Alignment.Center
-            ) {
-                Icon(
-                    imageVector = Icons.Default.AddPhotoAlternate,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onPrimaryContainer,
-                    modifier = Modifier.size(28.dp)
+        if (imageUri != null) {
+            Box {
+                AsyncImage(
+                    model = imageUri,
+                    contentDescription = "Cake Reference",
+                    modifier = Modifier.fillMaxSize(),
+                    contentScale = ContentScale.Crop
                 )
+                
+                // Small overlay to indicate it can be changed
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(Color.Black.copy(alpha = 0.2f))
+                        .padding(12.dp),
+                    contentAlignment = Alignment.BottomEnd
+                ) {
+                    Surface(
+                        color = Color.Black.copy(alpha = 0.5f),
+                        shape = CircleShape
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Edit,
+                            contentDescription = "Muda Foto",
+                            tint = Color.White,
+                            modifier = Modifier.padding(8.dp).size(16.dp)
+                        )
+                    }
+                }
             }
-            
-            Spacer(modifier = Modifier.width(16.dp))
-            
-            Column {
-                Text(
-                    text = "Adisiona Imajen Referénsia",
-                    style = MaterialTheme.typography.titleSmall,
-                    fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.onSurface
-                )
-                Spacer(modifier = Modifier.height(2.dp))
-                Text(
-                    text = "Hili husi galeria ka foti foto foun",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
+        } else {
+            Row(
+                modifier = Modifier
+                    .padding(16.dp)
+                    .fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(56.dp)
+                        .clip(RoundedCornerShape(12.dp))
+                        .background(MaterialTheme.colorScheme.primaryContainer),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.AddPhotoAlternate,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                        modifier = Modifier.size(28.dp)
+                    )
+                }
+                
+                Spacer(modifier = Modifier.width(16.dp))
+                
+                Column {
+                    Text(
+                        text = "Adisiona Imajen Referénsia",
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+                    Spacer(modifier = Modifier.height(2.dp))
+                    Text(
+                        text = "Hili husi galeria ka foti foto foun",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/example/ordermanagementcake/ui/forms/cakes/NewCakeForm.kt
+++ b/app/src/main/java/com/example/ordermanagementcake/ui/forms/cakes/NewCakeForm.kt
@@ -60,6 +60,7 @@ import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.tooling.preview.Preview
@@ -67,6 +68,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.ordermanagementcake.data.draft.CakeDraft
 import com.example.ordermanagementcake.data.draft.TierDraft
+import com.example.ordermanagementcake.data.util.ImageHelper
 import com.example.ordermanagementcake.ui.forms.tier.NewTierForm
 import com.example.ordermanagementcake.ui.orders.NewOrderViewModel
 import com.example.ordermanagementcake.ui.theme.OrderManagementCakeTheme
@@ -88,25 +90,31 @@ fun NewCakeForm(
     var showTierForm by remember { mutableStateOf(false) }
     var showImageSourceDialog by remember { mutableStateOf(false) }
     val sheetState = rememberModalBottomSheetState()
+    val context = LocalContext.current
 
     // Launcher ba Galeria
     val galleryLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.GetContent()
     ) { uri ->
         if (uri != null) {
-            imageUri = uri.toString()
-            println("Image selected from gallery: $uri")
+            val internalPath = ImageHelper.saveImageToInternalStorage(context, uri)
+            if (internalPath != null) {
+                imageUri = internalPath
+                println("Image saved to internal storage: $internalPath")
+            }
         }
-    }
+    }3
 
     // Launcher ba camera nian
     val cameraLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.TakePicturePreview()
     ) { bitmap ->
-
-        // IF the camera taksea picture which make it not null
         if (bitmap != null) {
-            println("Camera Opened and photo taken")
+            val internalPath = ImageHelper.saveBitmapToInternalStorage(context, bitmap)
+            if (internalPath != null) {
+                imageUri = internalPath
+                println("Camera photo saved to internal storage: $internalPath")
+            }
         }
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,8 +15,10 @@ uiText = "1.10.6"
 animation = "1.11.0"
 adapters = "3.2.0-alpha11"
 uiGraphics = "1.11.2"
+coil = "2.7.0"
 
 [libraries]
+coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
 androidx-compose-material-icons-core = { group = "androidx.compose.material", name = "material-icons-core" }
 androidx-compose-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }


### PR DESCRIPTION
## Sumario

- Aumenta Botto Border sheet atu hili opsain 
- Aumenta opsaun ba hili imag source: Camea, Gallery
- Attach image preview ba iha form 
- Save ba dtabase nia URI
- `ImageHelper.kt` Copy mos image Uri ba iha internal storage `com.example.ordermanagement` atu handle se quando user muda ka hapus foto 

### Preview
<img width="443" height="1006" alt="screenshot_2026-06-13_12-47-56" src="https://github.com/user-attachments/assets/533b8981-73f3-46e1-b588-371f0aa5c61b" />
<img width="438" height="394" alt="screenshot_2026-06-13_12-48-19" src="https://github.com/user-attachments/assets/d96e0127-4ffe-4035-a743-1c34f4f9c8c9" />





Fixes: #138 