### PR TITLE
Remove profile picture icon from topBar

### DIFF
--- a/app/src/main/java/com/example/ordermanagementcake/ui/components/AppTopBar.kt
+++ b/app/src/main/java/com/example/ordermanagementcake/ui/components/AppTopBar.kt
@@ -49,18 +49,7 @@ fun AppTopBar(
                 )
             }
         },
-        actions = {
-            IconButton(onClick = {}) {
-                Image(
-                    painter = painterResource(id = R.drawable.foto_profile),
-                    contentDescription = "Foto Profile",
-                    contentScale = ContentScale.Crop,
-                    modifier = Modifier
-                        .size(48.dp)
-                        .clip(CircleShape)
-                )
-            }
-        },
+        actions = {},
         colors = TopAppBarDefaults.topAppBarColors(
             containerColor             = extendedColors.sourceColor,
             navigationIconContentColor = MaterialTheme.colorScheme.onPrimary,


### PR DESCRIPTION
Removed the profile picture icon from the AppTopBar actions section.

## Changes
- Removed the profile picture icon that was using R.drawable.foto_profile resource
- The icon was located on the far right side of the top bar
- Actions section is now empty

## Testing
- Top bar should display without the profile picture icon
- Menu icon on the left and title should remain unchanged