### PR TITLE
fix: Prefill TierForm with existing tiers when modifying

### DIFF
--- a/app/src/main/java/com/example/ordermanagementcake/ui/forms/cakes/NewCakeForm.kt
+++ b/app/src/main/java/com/example/ordermanagementcake/ui/forms/cakes/NewCakeForm.kt
@@ -176,6 +176,7 @@ fun NewCakeForm(
                 tiers = newTiers
                 showTierForm = false
             },
+            initialTiers = tiers,
             viewModel = viewModel
         )
     }

--- a/app/src/main/java/com/example/ordermanagementcake/ui/forms/tier/NewTierForm.kt
+++ b/app/src/main/java/com/example/ordermanagementcake/ui/forms/tier/NewTierForm.kt
@@ -57,21 +57,29 @@ data class TierData(
 fun NewTierForm(
     onDismiss: () -> Unit = {},
     onSave: (List<TierDraft>) -> Unit = { _ -> },
+    initialTiers: List<TierDraft> = emptyList(),
     viewModel: NewOrderViewModel? = null
 ) {
     val extendedColors = MaterialTheme.extendedColors
     val surfaceColor = extendedColors.surfaceContainerLowest
 
     // Estadu ba nívél ne'ebé sedang hili (Active tier level selection)
-    var activeTierLevel by remember { mutableIntStateOf(1) }
+    var activeTierLevel by remember { mutableIntStateOf(initialTiers.firstOrNull()?.level ?: 1) }
     
     // Inisializa nívél 1 to'o 12 (1..12)
     val tiersState = remember { 
         val initialMap = mutableStateMapOf<Int, TierData>()
-        // Only initialize level 1 by default, or maybe let user add levels?
-        // The original code initialized 1..12. I'll stick to that but maybe it's too many.
-        for (i in 1..1) {
-            initialMap[i] = TierData()
+        if (initialTiers.isNotEmpty()) {
+            initialTiers.forEach { draft ->
+                initialMap[draft.level] = TierData(
+                    shape = draft.shape,
+                    size = draft.size,
+                    color = draft.color,
+                    price = draft.price
+                )
+            }
+        } else {
+            initialMap[1] = TierData()
         }
         initialMap
     }


### PR DESCRIPTION
## Summary

When clicking the "Modifika Nível" button in the cake form, the tier form now opens pre-filled with the previously added tier data instead of starting blank.

### Changes

**`NewTierForm.kt`**
- Added `initialTiers: List<TierDraft> = emptyList()` parameter
- `tiersState` now maps each existing `TierDraft` to a `TierData` entry when `initialTiers` is provided
- `activeTierLevel` defaults to the first tier's level when prefilled

**`NewCakeForm.kt`**
- Passes `initialTiers = tiers` to `NewTierForm`, so existing tiers populate the form on modify

### Before
Clicking "Modifika Nível" opened an empty form with only level 1, losing all previously added tier data.

### After
Clicking "Modifika Nível" opens the form with all existing tiers pre-populated and editable.

Fixes #157