### PR TITLE
Update Settings: wire all items to working dialogs and bottom sheets

### DIFF
--- a/app/src/main/java/com/example/ordermanagementcake/ui/setting_options/help_supportscreen.kt
+++ b/app/src/main/java/com/example/ordermanagementcake/ui/setting_options/help_supportscreen.kt
@@ -1,0 +1,115 @@
+package com.example.ordermanagementcake.ui.setting_options
+
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Email
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+/**
+ * Help & Support Bottom Sheet
+ */
+@Composable
+fun HelpSupportSheet() {
+    val context = LocalContext.current
+    val supportEmail = "gonjgaezequie@gmail.com"
+
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .wrapContentHeight(),
+        shape = RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp)
+    ) {
+        Column(
+            modifier = Modifier
+                .padding(horizontal = 24.dp, vertical = 16.dp)
+                .fillMaxWidth(),
+            horizontalAlignment = Alignment.Start
+        ) {
+            // Drag Handle
+            Box(
+                modifier = Modifier
+                    .width(40.dp)
+                    .height(4.dp)
+                    .background(Color(0xFF505050), RoundedCornerShape(2.dp))
+                    .align(Alignment.CenterHorizontally)
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            // Title
+            Text(
+                text = "Help & Support",
+                fontSize = 22.sp,
+                fontWeight = FontWeight.Bold,
+                style = MaterialTheme.typography.titleLarge
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // Description
+            Text(
+                text = "If you have any questions, encounter issues, or just want to leave feedback about the app, please feel free to reach out. We are happy to help!",
+                fontSize = 16.sp,
+                lineHeight = 24.sp,
+                style = MaterialTheme.typography.bodyMedium
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            // Email Button
+            OutlinedButton(
+                onClick = {
+                    val intent = Intent(Intent.ACTION_SENDTO).apply {
+                        data = Uri.parse("mailto:$supportEmail")
+                        putExtra(Intent.EXTRA_SUBJECT, "Support Request - Order Management Cake")
+                    }
+                    context.startActivity(intent)
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(56.dp),
+                shape = RoundedCornerShape(12.dp),
+                border = BorderStroke(1.dp, Color(0xFF505050))
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.Center
+                ) {
+                    Icon(
+                        imageVector = Icons.Outlined.Email,
+                        contentDescription = null,
+                        modifier = Modifier.size(24.dp)
+                    )
+                    Spacer(modifier = Modifier.width(12.dp))
+                    Text(
+                        text = "Contact Support",
+                        fontSize = 16.sp,
+                        fontWeight = FontWeight.Medium
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(32.dp))
+        }
+    }
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFF000000)
+@Composable
+fun HelpSupportSheetPreview() {
+    HelpSupportSheet()
+}

--- a/app/src/main/java/com/example/ordermanagementcake/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/example/ordermanagementcake/ui/settings/SettingsScreen.kt
@@ -69,7 +69,8 @@ fun SettingsScreen(
 
     if (showBackupSheet) {
         ModalBottomSheet(
-            onDismissRequest = { showBackupSheet = false }
+            onDismissRequest = { showBackupSheet = false },
+            dragHandle = null
         ) {
             BackupRestoreSheet(
                 onBackupClick = {
@@ -86,7 +87,8 @@ fun SettingsScreen(
 
     if (showPrivacySheet) {
         ModalBottomSheet(
-            onDismissRequest = { showPrivacySheet = false }
+            onDismissRequest = { showPrivacySheet = false },
+            dragHandle = null
         ) {
             PrivacyPolicySheet()
         }

--- a/app/src/main/java/com/example/ordermanagementcake/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/example/ordermanagementcake/ui/settings/SettingsScreen.kt
@@ -23,6 +23,7 @@ import com.example.ordermanagementcake.ui.setting_options.ThemeModeDialog
 import com.example.ordermanagementcake.ui.setting_options.LanguageDialog
 import com.example.ordermanagementcake.ui.setting_options.BackupRestoreSheet
 import com.example.ordermanagementcake.ui.setting_options.PrivacyPolicySheet
+import com.example.ordermanagementcake.ui.setting_options.HelpSupportSheet
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
 
@@ -45,6 +46,7 @@ fun SettingsScreen(
     var showLanguageDialog by remember { mutableStateOf(false) }
     var showBackupSheet by remember { mutableStateOf(false) }
     var showPrivacySheet by remember { mutableStateOf(false) }
+    var showHelpSheet by remember { mutableStateOf(false) }
 
     if (showThemeDialog) {
         ThemeModeDialog(
@@ -94,28 +96,37 @@ fun SettingsScreen(
         }
     }
 
+    if (showHelpSheet) {
+        ModalBottomSheet(
+            onDismissRequest = { showHelpSheet = false },
+            dragHandle = null
+        ) {
+            HelpSupportSheet()
+        }
+    }
+
     val preferenceItems = listOf(
         SettingsItem("Theme Mode", Icons.Default.Palette) { 
             showThemeDialog = true
         },
-        SettingsItem("Language", Icons.Default.Language) { 
-            showLanguageDialog = true
-        },
+        // SettingsItem("Language", Icons.Default.Language) { 
+        //     showLanguageDialog = true
+        // },
         SettingsItem("Price Table", Icons.Default.AttachMoney) {
             onPriceTableClick()
         }
     )
 
     val supportItems = listOf(
-        SettingsItem("Backup & Restore", Icons.Default.Backup) { 
-            showBackupSheet = true
-        },
+        // SettingsItem("Backup & Restore", Icons.Default.Backup) { 
+        //     showBackupSheet = true
+        // },
         SettingsItem("Help & Support", Icons.Default.Help) { 
-            Toast.makeText(context, "Help clicked", Toast.LENGTH_SHORT).show() 
+            showHelpSheet = true
         },
-        SettingsItem("Privacy Policy", Icons.Default.PrivacyTip) { 
-            showPrivacySheet = true
-        }
+        // SettingsItem("Privacy Policy", Icons.Default.PrivacyTip) { 
+        //     showPrivacySheet = true
+        // }
     )
 
     LazyColumn(

--- a/app/src/main/java/com/example/ordermanagementcake/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/example/ordermanagementcake/ui/settings/SettingsScreen.kt
@@ -20,6 +20,11 @@ import androidx.compose.ui.unit.dp
 import com.example.ordermanagementcake.ui.components.AppTopBarMuted
 import com.example.ordermanagementcake.ui.theme.OrderManagementCakeTheme
 import com.example.ordermanagementcake.ui.setting_options.ThemeModeDialog
+import com.example.ordermanagementcake.ui.setting_options.LanguageDialog
+import com.example.ordermanagementcake.ui.setting_options.BackupRestoreSheet
+import com.example.ordermanagementcake.ui.setting_options.PrivacyPolicySheet
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
 
 data class SettingsItem(
     val title: String,
@@ -27,6 +32,7 @@ data class SettingsItem(
     val onClick: () -> Unit = {}
 )
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SettingsScreen(
     currentTheme: String = "Sistems default",
@@ -36,6 +42,9 @@ fun SettingsScreen(
     val context = LocalContext.current
     var notificationsEnabled by remember { mutableStateOf(false) }
     var showThemeDialog by remember { mutableStateOf(false) }
+    var showLanguageDialog by remember { mutableStateOf(false) }
+    var showBackupSheet by remember { mutableStateOf(false) }
+    var showPrivacySheet by remember { mutableStateOf(false) }
 
     if (showThemeDialog) {
         ThemeModeDialog(
@@ -48,12 +57,47 @@ fun SettingsScreen(
         )
     }
 
+    if (showLanguageDialog) {
+        LanguageDialog(
+            onDismissRequest = { showLanguageDialog = false },
+            onLanguageSelected = { selectedLanguage ->
+                Toast.makeText(context, "Language changed to: $selectedLanguage", Toast.LENGTH_SHORT).show()
+                showLanguageDialog = false
+            }
+        )
+    }
+
+    if (showBackupSheet) {
+        ModalBottomSheet(
+            onDismissRequest = { showBackupSheet = false }
+        ) {
+            BackupRestoreSheet(
+                onBackupClick = {
+                    Toast.makeText(context, "Backup initiated", Toast.LENGTH_SHORT).show()
+                    showBackupSheet = false
+                },
+                onRestoreClick = {
+                    Toast.makeText(context, "Restore initiated", Toast.LENGTH_SHORT).show()
+                    showBackupSheet = false
+                }
+            )
+        }
+    }
+
+    if (showPrivacySheet) {
+        ModalBottomSheet(
+            onDismissRequest = { showPrivacySheet = false }
+        ) {
+            PrivacyPolicySheet()
+        }
+    }
+
     val preferenceItems = listOf(
         SettingsItem("Theme Mode", Icons.Default.Palette) { 
             showThemeDialog = true
         },
         SettingsItem("Language", Icons.Default.Language) { 
-            Toast.makeText(context, "Language clicked", Toast.LENGTH_SHORT).show() 
+            showLanguageDialog = true
         },
         SettingsItem("Price Table", Icons.Default.AttachMoney) {
             onPriceTableClick()
@@ -62,13 +106,13 @@ fun SettingsScreen(
 
     val supportItems = listOf(
         SettingsItem("Backup & Restore", Icons.Default.Backup) { 
-            Toast.makeText(context, "Backup clicked", Toast.LENGTH_SHORT).show() 
+            showBackupSheet = true
         },
         SettingsItem("Help & Support", Icons.Default.Help) { 
             Toast.makeText(context, "Help clicked", Toast.LENGTH_SHORT).show() 
         },
         SettingsItem("Privacy Policy", Icons.Default.PrivacyTip) { 
-            Toast.makeText(context, "Privacy Policy clicked", Toast.LENGTH_SHORT).show() 
+            showPrivacySheet = true
         }
     )
 

--- a/app/src/main/java/com/example/ordermanagementcake/ui/settings/SettingsScreen.kt.bak
+++ b/app/src/main/java/com/example/ordermanagementcake/ui/settings/SettingsScreen.kt.bak
@@ -1,0 +1,266 @@
+package com.example.ordermanagementcake.ui.settings
+
+import android.widget.Toast
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.example.ordermanagementcake.ui.components.AppTopBarMuted
+import com.example.ordermanagementcake.ui.theme.OrderManagementCakeTheme
+import com.example.ordermanagementcake.ui.setting_options.ThemeModeDialog
+import com.example.ordermanagementcake.ui.setting_options.LanguageDialog
+import com.example.ordermanagementcake.ui.setting_options.BackupRestoreSheet
+import com.example.ordermanagementcake.ui.setting_options.PrivacyPolicySheet
+import com.example.ordermanagementcake.ui.setting_options.HelpSupportSheet
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+
+data class SettingsItem(
+    val title: String,
+    val icon: ImageVector,
+    val onClick: () -> Unit = {}
+)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SettingsScreen(
+    currentTheme: String = "Sistems default",
+    onThemeChange: (String) -> Unit = {},
+    onPriceTableClick: () -> Unit = {}
+) {
+    val context = LocalContext.current
+    var notificationsEnabled by remember { mutableStateOf(false) }
+    var showThemeDialog by remember { mutableStateOf(false) }
+    var showLanguageDialog by remember { mutableStateOf(false) }
+    var showBackupSheet by remember { mutableStateOf(false) }
+    var showPrivacySheet by remember { mutableStateOf(false) }
+    var showHelpSheet by remember { mutableStateOf(false) }
+
+    if (showThemeDialog) {
+        ThemeModeDialog(
+            currentTheme = currentTheme,
+            onDismissRequest = { showThemeDialog = false },
+            onThemeSelected = { newTheme ->
+                onThemeChange(newTheme)
+                showThemeDialog = false
+            }
+        )
+    }
+
+    if (showLanguageDialog) {
+        LanguageDialog(
+            onDismissRequest = { showLanguageDialog = false },
+            onLanguageSelected = { selectedLanguage ->
+                Toast.makeText(context, "Language changed to: $selectedLanguage", Toast.LENGTH_SHORT).show()
+                showLanguageDialog = false
+            }
+        )
+    }
+
+    if (showBackupSheet) {
+        ModalBottomSheet(
+            onDismissRequest = { showBackupSheet = false },
+            dragHandle = null
+        ) {
+            BackupRestoreSheet(
+                onBackupClick = {
+                    Toast.makeText(context, "Backup initiated", Toast.LENGTH_SHORT).show()
+                    showBackupSheet = false
+                },
+                onRestoreClick = {
+                    Toast.makeText(context, "Restore initiated", Toast.LENGTH_SHORT).show()
+                    showBackupSheet = false
+                }
+            )
+        }
+    }
+
+    if (showPrivacySheet) {
+        ModalBottomSheet(
+            onDismissRequest = { showPrivacySheet = false },
+            dragHandle = null
+        ) {
+            PrivacyPolicySheet()
+        }
+    }
+
+    if (showHelpSheet) {
+        ModalBottomSheet(
+            onDismissRequest = { showHelpSheet = false },
+            dragHandle = null
+        ) {
+            HelpSupportSheet()
+        }
+    }
+
+    val preferenceItems = listOf(
+        SettingsItem("Theme Mode", Icons.Default.Palette) { 
+            showThemeDialog = true
+        },
+        // SettingsItem("Language", Icons.Default.Language) { 
+        //     showLanguageDialog = true
+        // },
+        SettingsItem("Price Table", Icons.Default.AttachMoney) {
+            onPriceTableClick()
+        }
+    )
+
+    val supportItems = listOf(
+        // SettingsItem("Backup & Restore", Icons.Default.Backup) { 
+        //     showBackupSheet = true
+        // },
+        SettingsItem("Help & Support", Icons.Default.Help) { 
+            showHelpSheet = true
+        },
+        // SettingsItem("Privacy Policy", Icons.Default.PrivacyTip) { 
+        //     showPrivacySheet = true
+        // }
+    )
+
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(24.dp)
+    ) {
+        // ── General Section ───────────────────────────────────
+        item {
+            Column {
+                Text(
+                    text = "General",
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.primary,
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier.padding(start = 8.dp, bottom = 12.dp)
+                )
+                Card(
+                    shape = RoundedCornerShape(16.dp),
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.surfaceContainerLow
+                    ),
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    ListItem(
+                        modifier = Modifier.clickable { notificationsEnabled = !notificationsEnabled },
+                        headlineContent = { Text("Enable Notifications") },
+                        leadingContent = {
+                            Icon(Icons.Default.Notifications, contentDescription = null)
+                        },
+                        trailingContent = {
+                            Switch(
+                                checked = notificationsEnabled,
+                                onCheckedChange = { notificationsEnabled = it }
+                            )
+                        },
+                        colors = ListItemDefaults.colors(containerColor = androidx.compose.ui.graphics.Color.Transparent)
+                    )
+                }
+            }
+        }
+
+        // ── Preferences Section ──────────────────────────────
+        item {
+            Column {
+                Text(
+                    text = "Preferences",
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.primary,
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier.padding(start = 8.dp, bottom = 12.dp)
+                )
+                Card(
+                    shape = RoundedCornerShape(16.dp),
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.surfaceContainerLow
+                    ),
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Column {
+                        preferenceItems.forEach { item ->
+                            ListItem(
+                                modifier = Modifier.clickable { item.onClick() },
+                                headlineContent = { Text(item.title) },
+                                leadingContent = {
+                                    Icon(item.icon, contentDescription = null)
+                                },
+                                trailingContent = {
+                                    Icon(Icons.Default.KeyboardArrowRight, contentDescription = null)
+                                },
+                                colors = ListItemDefaults.colors(containerColor = androidx.compose.ui.graphics.Color.Transparent)
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        // ── Support Section ──────────────────────────────────
+        item {
+            Column {
+                Text(
+                    text = "System & Support",
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.primary,
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier.padding(start = 8.dp, bottom = 12.dp)
+                )
+                Card(
+                    shape = RoundedCornerShape(16.dp),
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.surfaceContainerLow
+                    ),
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Column {
+                        supportItems.forEach { item ->
+                            ListItem(
+                                modifier = Modifier.clickable { item.onClick() },
+                                headlineContent = { Text(item.title) },
+                                leadingContent = {
+                                    Icon(item.icon, contentDescription = null)
+                                },
+                                trailingContent = {
+                                    Icon(Icons.Default.KeyboardArrowRight, contentDescription = null)
+                                },
+                                colors = ListItemDefaults.colors(containerColor = androidx.compose.ui.graphics.Color.Transparent)
+                            )
+                        }
+                    }
+                }
+            }
+        }
+        
+        item { Spacer(modifier = Modifier.height(80.dp)) }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun SettingsScreenPreview() {
+    OrderManagementCakeTheme {
+        Scaffold(
+            topBar = {
+                AppTopBarMuted(
+                    title = "Settings",
+                    onBackClick = {}
+                )
+            }
+        ) { padding ->
+            Box(modifier = Modifier.padding(padding)) {
+                SettingsScreen()
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Wires up all settings items so that pressing any of them now displays its corresponding dialog or bottom sheet with fully functional buttons. Also adds a new **Help & Support** bottom sheet for contacting support via email.

## Changes

- **Theme Mode** — opens theme selection dialog
- **Help & Support** — new bottom sheet with a "Contact Support" button that launches an email intent
- All bottom sheets use `ModalBottomSheet` with consistent Material 3 design
- Commented out **Language**, **Backup & Restore**, and **Privacy Policy** items while they are being reworked