### PR TITLE
fix: prevent initForEdit from overwriting unsaved draft changes on nav pop; show time in delivery date card

### DIFF
--- a/app/src/main/java/com/example/ordermanagementcake/data/draft/DraftModels.kt
+++ b/app/src/main/java/com/example/ordermanagementcake/data/draft/DraftModels.kt
@@ -19,6 +19,7 @@ data class CakeDraft(
 )
 
 data class OrderDraft(
+    val orderId: Int? = null,
     val clientId: Int? = null,
     val clientName: String? = null,
     val orderDate: String = "",

--- a/app/src/main/java/com/example/ordermanagementcake/data/repository/OrderRepository.kt
+++ b/app/src/main/java/com/example/ordermanagementcake/data/repository/OrderRepository.kt
@@ -26,6 +26,9 @@ class OrderRepository(private val orderDao: OrderDao) {
     suspend fun insertOrder(order: OrderEntity): Long =
         orderDao.insertOrder(order)
 
+    suspend fun updateOrder(order: OrderEntity) =
+        orderDao.updateOrder(order)
+
     suspend fun updateStatus(orderId: Int, status: OrderStatus) =
         orderDao.updateStatus(orderId, status)
 

--- a/app/src/main/java/com/example/ordermanagementcake/ui/clients/ClientDetailScreen.kt
+++ b/app/src/main/java/com/example/ordermanagementcake/ui/clients/ClientDetailScreen.kt
@@ -1,5 +1,7 @@
 package com.example.ordermanagementcake.ui.clients
 
+import android.content.Intent
+import android.net.Uri
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
@@ -7,6 +9,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Chat
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -15,6 +18,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -40,6 +44,7 @@ fun ClientDetail(
 
     val client = clientWithOrders.client
     val orders = clientWithOrders.orders
+    val context = LocalContext.current
     var showEditForm by remember { mutableStateOf(false) }
 
     Column(
@@ -130,11 +135,18 @@ fun ClientDetail(
                 contentColor = MaterialTheme.colorScheme.onPrimary
             )
             ActionButton(
-                icon = Icons.Default.Email,
-                label = "Kontaktu",
+                icon = Icons.AutoMirrored.Filled.Chat,
+                label = "WhatsApp",
+                onClick = {
+                    val phoneClean = client.phone.replace(Regex("[^\\d+]"), "").removePrefix("+")
+                    try {
+                        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://wa.me/$phoneClean"))
+                        context.startActivity(intent)
+                    } catch (_: Exception) { }
+                },
                 modifier = Modifier.weight(1f),
-                containerColor = MaterialTheme.colorScheme.surfaceVariant,
-                contentColor = MaterialTheme.colorScheme.primary
+                containerColor = Color(0xFF25D366),
+                contentColor = Color.White
             )
         }
     }
@@ -361,12 +373,13 @@ fun OrderItem(title: String, date: String, time: String, price: String, status: 
 fun ActionButton(
     icon: ImageVector,
     label: String,
+    onClick: () -> Unit = {},
     modifier: Modifier = Modifier,
     containerColor: Color,
     contentColor: Color
 ) {
     Button(
-        onClick = { },
+        onClick = onClick,
         modifier = modifier.height(50.dp),
         colors = ButtonDefaults.buttonColors(
             containerColor = containerColor,

--- a/app/src/main/java/com/example/ordermanagementcake/ui/forms/cakes/NewCakeForm.kt
+++ b/app/src/main/java/com/example/ordermanagementcake/ui/forms/cakes/NewCakeForm.kt
@@ -88,14 +88,15 @@ fun NewCakeForm(
     onSaveCake: (CakeDraft) -> Unit = {},
     onBack: () -> Unit = {},
     clientName: String = "Sophie Chen",
-    viewModel: NewOrderViewModel? = null
+    viewModel: NewOrderViewModel? = null,
+    initialCake: CakeDraft? = null
 ) {
-    var cakeTitle by remember { mutableStateOf("") }
-    var cakeNotes by remember { mutableStateOf("") }
-    var imageUri by remember { mutableStateOf<String?>(null) }
-    var bakingDate by remember { mutableStateOf<String?>(null) }
+    var cakeTitle by remember { mutableStateOf(initialCake?.cakeTitle ?: "") }
+    var cakeNotes by remember { mutableStateOf(initialCake?.cakeNotes ?: "") }
+    var imageUri by remember { mutableStateOf(initialCake?.imageUri) }
+    var bakingDate by remember { mutableStateOf(initialCake?.bakingDate) }
     var showDatePicker by remember { mutableStateOf(false) }
-    var tiers by remember { mutableStateOf(emptyList<TierDraft>()) }
+    var tiers by remember { mutableStateOf(initialCake?.tiers ?: emptyList()) }
     var showTierForm by remember { mutableStateOf(false) }
     var showImageSourceDialog by remember { mutableStateOf(false) }
     val sheetState = rememberModalBottomSheetState()

--- a/app/src/main/java/com/example/ordermanagementcake/ui/forms/orders/NewOrderForm.kt
+++ b/app/src/main/java/com/example/ordermanagementcake/ui/forms/orders/NewOrderForm.kt
@@ -537,7 +537,7 @@ fun NewOrderForm(
                                 cornerRadius = CornerRadius(12.dp.toPx())
                             )
                         }
-                        .clickable { onNewCake() },
+                        .clickable { viewModel.clearEditingCake(); onNewCake() },
                     contentAlignment = Alignment.Center
                 ) {
                     Column(
@@ -576,10 +576,13 @@ fun NewOrderForm(
             } else {
                 Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                     draft.cakes.forEachIndexed { index, cake ->
-                        CakeDraftItem(cake, onDelete = { viewModel.removeCakeFromDraft(index) })
+                        CakeDraftItem(cake, onDelete = { viewModel.removeCakeFromDraft(index) }, onEdit = {
+                            viewModel.startEditingCake(index)
+                            onNewCake()
+                        })
                     }
                     Button(
-                        onClick = onNewCake,
+                        onClick = { viewModel.clearEditingCake(); onNewCake() },
                         modifier = Modifier.fillMaxWidth(),
                         colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.secondaryContainer)
                     ) {
@@ -674,9 +677,11 @@ fun NewOrderForm(
 }
 
 @Composable
-fun CakeDraftItem(cake: CakeDraft, onDelete: () -> Unit) {
+fun CakeDraftItem(cake: CakeDraft, onDelete: () -> Unit, onEdit: () -> Unit = {}) {
     Card(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onEdit() },
         shape = RoundedCornerShape(16.dp),
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.extendedColors.surfaceContainerLow)
     ) {

--- a/app/src/main/java/com/example/ordermanagementcake/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/example/ordermanagementcake/ui/navigation/NavGraph.kt
@@ -421,14 +421,16 @@ fun AppNavHost(
                     )
                 }
                 composable(route = Routes.NEW_CAKE) {
+                    val editingCake = newOrderViewModel.getEditingCake()
                     NewCakeForm(
                         onSaveCake = { cakeDraft ->
-                            newOrderViewModel.addCakeToDraft(cakeDraft)
+                            newOrderViewModel.addOrUpdateCake(cakeDraft)
                             navController.popBackStack()
                         },
                         onBack = { navController.popBackStack() },
                         clientName = newOrderViewModel.orderDraft.clientName ?: "Kliente foun",
-                        viewModel = newOrderViewModel
+                        viewModel = newOrderViewModel,
+                        initialCake = editingCake
                     )
                 }
                 composable(route = Routes.SETTINGS) {

--- a/app/src/main/java/com/example/ordermanagementcake/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/example/ordermanagementcake/ui/navigation/NavGraph.kt
@@ -80,10 +80,12 @@ object Routes {
     const val NEW_CAKE = "new_cake"
     const val SETTINGS = "settings"
     const val PRICE_LIST = "price_list"
+    const val EDIT_ORDER = "edit_order/{orderID}"
 
 
     fun clientDetail(clientId: Int) = "client_detail/$clientId"
     fun orderDetail(orderId: Int) = "order_detail/$orderId"
+    fun editOrder(orderId: Int) = "edit_order/$orderId"
 
 }
 
@@ -207,6 +209,8 @@ fun AppNavHost(
                     }
                 } else if (currentRoute == Routes.NEW_ORDER) {
                     AppTopBarNewOrder(onBackClick = { navController.popBackStack()}, title = "Pedidu Foun")
+                } else if (currentRoute?.startsWith("edit_order/") == true) {
+                    AppTopBarNewOrder(onBackClick = { navController.popBackStack()}, title = "Edita Pedidu")
                 } else if (currentRoute == Routes.SETTINGS) {
                     AppTopBarMuted(onBackClick = { navController.popBackStack()}, title = "Configurasaun")
                 }
@@ -392,9 +396,27 @@ fun AppNavHost(
                     OrderDetailScreen(
                         orderDetail = uiState.selectedOrderDetail,
                         onBackClick = { navController.popBackStack() },
-                        onEditOrder = { /* TODO: Implement Edit Order */ },
+                        onEditOrder = { id ->
+                            navController.navigate(Routes.editOrder(id))
+                        },
                         onStatusChange = { newStatus ->
                             orderId?.let { orderViewModel.updateStatus(it, newStatus) }
+                        }
+                    )
+                }
+                composable(route = Routes.EDIT_ORDER) { navBackStackEntry ->
+                    val editOrderId = navBackStackEntry.arguments?.getString("orderID")?.toIntOrNull()
+
+                    LaunchedEffect(editOrderId) {
+                        editOrderId?.let { newOrderViewModel.initForEdit(it) }
+                    }
+
+                    NewOrderForm(
+                        viewModel = newOrderViewModel,
+                        onAddNewClient = { navController.navigate(Routes.NEW_CLIENT) },
+                        onNewCake = { navController.navigate(Routes.NEW_CAKE) },
+                        onSaveOrder = {
+                            navController.popBackStack()
                         }
                     )
                 }

--- a/app/src/main/java/com/example/ordermanagementcake/ui/orderdetail/OrderDetailScreen.kt
+++ b/app/src/main/java/com/example/ordermanagementcake/ui/orderdetail/OrderDetailScreen.kt
@@ -398,7 +398,9 @@ fun StatusControlCard(
             Spacer(modifier = Modifier.height(12.dp))
             
             Row(
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(IntrinsicSize.Min),
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
                 // If there's a next status, show the primary action button
@@ -414,7 +416,7 @@ fun StatusControlCard(
                         onClick = { showAdvanceDialog = true },
                         modifier = Modifier
                             .weight(1f)
-                            .height(48.dp),
+                            .fillMaxHeight(),
                         shape = RoundedCornerShape(12.dp),
                         colors = ButtonDefaults.buttonColors(
                             containerColor = buttonColor,
@@ -431,7 +433,7 @@ fun StatusControlCard(
                 if (currentStatus != OrderStatus.CANCELLED && currentStatus != OrderStatus.COMPLETED) {
                     OutlinedButton(
                         onClick = { showCancelDialog = true },
-                        modifier = Modifier.height(48.dp),
+                        modifier = Modifier.fillMaxHeight(),
                         shape = RoundedCornerShape(12.dp),
                         colors = ButtonDefaults.outlinedButtonColors(
                             contentColor = MaterialTheme.colorScheme.error

--- a/app/src/main/java/com/example/ordermanagementcake/ui/orderdetail/OrderDetailScreen.kt
+++ b/app/src/main/java/com/example/ordermanagementcake/ui/orderdetail/OrderDetailScreen.kt
@@ -1009,7 +1009,11 @@ private fun formatDisplayDate(dateString: String): String {
                     day % 10 == 3 -> "rd"
                     else -> "th"
                 }
-                return "$month $day$suffix, $year"
+                val time = if (dateString.contains(":")) {
+                    val timeSdf = java.text.SimpleDateFormat("HH:mm", Locale.US)
+                    " at ${timeSdf.format(date)}"
+                } else ""
+                return "$month $day$suffix, $year$time"
             }
         } catch (_: Exception) { }
     }

--- a/app/src/main/java/com/example/ordermanagementcake/ui/orders/NewOrderViewModel.kt
+++ b/app/src/main/java/com/example/ordermanagementcake/ui/orders/NewOrderViewModel.kt
@@ -57,6 +57,9 @@ class NewOrderViewModel(
     var orderDraft by mutableStateOf(OrderDraft())
         private set
 
+    var editingCakeIndex: Int? by mutableStateOf(null)
+        private set
+
     // Auto-pricing data
     val shapes: StateFlow<List<ShapeEntity>> = shapeRepository.getAllShapes()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
@@ -134,6 +137,32 @@ class NewOrderViewModel(
         }
     }
 
+    fun startEditingCake(index: Int) {
+        editingCakeIndex = index
+    }
+
+    fun clearEditingCake() {
+        editingCakeIndex = null
+    }
+
+    fun getEditingCake(): CakeDraft? {
+        val index = editingCakeIndex ?: return null
+        return orderDraft.cakes.getOrNull(index)
+    }
+
+    fun addOrUpdateCake(cake: CakeDraft) {
+        val index = editingCakeIndex
+        if (index != null && index in orderDraft.cakes.indices) {
+            val newCakes = orderDraft.cakes.toMutableList()
+            newCakes[index] = cake
+            orderDraft = orderDraft.copy(cakes = newCakes)
+            editingCakeIndex = null
+        } else {
+            orderDraft = orderDraft.copy(cakes = orderDraft.cakes + cake)
+        }
+        calculateTotalPrice()
+    }
+
     private fun calculateTotalPrice() {
         orderDraft = orderDraft.copy(totalPrice = orderDraft.calculateTotal())
     }
@@ -182,6 +211,7 @@ class NewOrderViewModel(
     fun resetDraft() {
         orderDraft = OrderDraft()
         _searchQuery.value = ""
+        editingCakeIndex = null
     }
 
     fun saveOrder(onSuccess: () -> Unit = {}) {

--- a/app/src/main/java/com/example/ordermanagementcake/ui/orders/NewOrderViewModel.kt
+++ b/app/src/main/java/com/example/ordermanagementcake/ui/orders/NewOrderViewModel.kt
@@ -60,6 +60,8 @@ class NewOrderViewModel(
     var editingCakeIndex: Int? by mutableStateOf(null)
         private set
 
+    private var initializedEditOrderId: Int? = null
+
     // Auto-pricing data
     val shapes: StateFlow<List<ShapeEntity>> = shapeRepository.getAllShapes()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
@@ -168,6 +170,8 @@ class NewOrderViewModel(
     }
 
     fun initForEdit(orderId: Int) {
+        if (initializedEditOrderId == orderId) return
+        initializedEditOrderId = orderId
         viewModelScope.launch {
             try {
                 val orderDetail = orderRepository.getOrderFullDetail(orderId).first() ?: return@launch
@@ -212,6 +216,7 @@ class NewOrderViewModel(
         orderDraft = OrderDraft()
         _searchQuery.value = ""
         editingCakeIndex = null
+        initializedEditOrderId = null
     }
 
     fun saveOrder(onSuccess: () -> Unit = {}) {

--- a/app/src/main/java/com/example/ordermanagementcake/ui/orders/NewOrderViewModel.kt
+++ b/app/src/main/java/com/example/ordermanagementcake/ui/orders/NewOrderViewModel.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.ordermanagementcake.data.draft.CakeDraft
 import com.example.ordermanagementcake.data.draft.OrderDraft
+import com.example.ordermanagementcake.data.draft.TierDraft
 import com.example.ordermanagementcake.data.local.entities.CakeEntity
 import com.example.ordermanagementcake.data.local.entities.ClientEntity
 import com.example.ordermanagementcake.data.local.entities.OrderEntity
@@ -137,6 +138,47 @@ class NewOrderViewModel(
         orderDraft = orderDraft.copy(totalPrice = orderDraft.calculateTotal())
     }
 
+    fun initForEdit(orderId: Int) {
+        viewModelScope.launch {
+            try {
+                val orderDetail = orderRepository.getOrderFullDetail(orderId).first() ?: return@launch
+                val allShapes = shapeRepository.getAllShapes().first()
+                val allSizes = sizeRepository.getAllSizes().first()
+
+                val cakeDrafts = orderDetail.cakes.map { cakeWithTiers ->
+                    CakeDraft(
+                        cakeTitle = cakeWithTiers.cake.cakeTitle,
+                        cakeNotes = cakeWithTiers.cake.cakeNotes,
+                        imageUri = cakeWithTiers.cake.imageUri,
+                        bakingDate = cakeWithTiers.cake.bakingDate,
+                        tiers = cakeWithTiers.tiers.map { tier ->
+                            TierDraft(
+                                level = tier.level,
+                                shape = allShapes.find { it.id == tier.shapeId }?.shapeName ?: "Circle",
+                                size = "${allSizes.find { it.id == tier.sizeId }?.inches ?: tier.sizeId}\"",
+                                color = try { Color(android.graphics.Color.parseColor(tier.colorHex)) } catch (e: Exception) { Color.Gray },
+                                price = tier.price
+                            )
+                        }
+                    )
+                }
+
+                orderDraft = OrderDraft(
+                    orderId = orderDetail.order.id,
+                    clientId = orderDetail.client.id,
+                    clientName = orderDetail.client.name,
+                    deliveryDate = orderDetail.order.deliveryDate,
+                    orderNotes = orderDetail.order.orderNotes,
+                    totalPrice = orderDetail.order.totalPrice,
+                    cakes = cakeDrafts
+                )
+                _searchQuery.value = orderDetail.client.name
+            } catch (e: Exception) {
+                Log.e(TAG, "Error loading order for edit: ${e.message}", e)
+            }
+        }
+    }
+
     fun resetDraft() {
         orderDraft = OrderDraft()
         _searchQuery.value = ""
@@ -144,12 +186,11 @@ class NewOrderViewModel(
 
     fun saveOrder(onSuccess: () -> Unit = {}) {
         Log.d(TAG, "Starting saveOrder process...")
-        
+
         viewModelScope.launch {
             try {
-                // 1. Resolve a valid Client ID
                 var finalClientId = orderDraft.clientId
-                
+
                 if (finalClientId == null || finalClientId == 0) {
                     Log.d(TAG, "No Client ID in draft. Searching for existing clients...")
                     val allClients = clientRepository.getAllClients().first()
@@ -162,21 +203,46 @@ class NewOrderViewModel(
                     }
                 }
 
-                Log.d(TAG, "Inserting Order for client ID: $finalClientId")
-                // A. Save Order (Get ID)
-                val orderId = orderRepository.insertOrder(
-                    OrderEntity(
-                        customerId = finalClientId!!,
-                        orderDate = SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.US).format(Date()),
-                        deliveryDate = orderDraft.deliveryDate,
-                        totalPrice = orderDraft.totalPrice,
-                        orderNotes = orderDraft.orderNotes,
-                        status = OrderStatus.PENDING
-                    )
-                ).toInt()
-                Log.d(TAG, "Order inserted successfully. ID: $orderId")
+                val isEditing = orderDraft.orderId != null
+                val orderId: Int
 
-                // B. Loop Cakes
+                if (isEditing) {
+                    // === EDIT MODE ===
+                    orderId = orderDraft.orderId!!
+                    val existing = orderRepository.getOrderFullDetail(orderId).first()
+                    if (existing == null) {
+                        Log.e(TAG, "Order to edit not found: $orderId")
+                        return@launch
+                    }
+
+                    Log.d(TAG, "Updating Order ID: $orderId")
+                    orderRepository.updateOrder(
+                        existing.order.copy(
+                            customerId = finalClientId!!,
+                            deliveryDate = orderDraft.deliveryDate,
+                            totalPrice = orderDraft.totalPrice,
+                            orderNotes = orderDraft.orderNotes
+                        )
+                    )
+
+                    cakeRepository.deleteCakesForOrder(orderId)
+                } else {
+                    // === CREATE MODE ===
+                    Log.d(TAG, "Inserting Order for client ID: $finalClientId")
+                    orderId = orderRepository.insertOrder(
+                        OrderEntity(
+                            customerId = finalClientId!!,
+                            orderDate = SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.US).format(Date()),
+                            deliveryDate = orderDraft.deliveryDate,
+                            totalPrice = orderDraft.totalPrice,
+                            orderNotes = orderDraft.orderNotes,
+                            status = OrderStatus.PENDING
+                        )
+                    ).toInt()
+                    Log.d(TAG, "Order inserted successfully. ID: $orderId")
+                }
+
+                // Insert cakes and tiers (same for both modes)
                 orderDraft.cakes.forEachIndexed { index, cakeDraft ->
                     Log.d(TAG, "Inserting Cake #$index: ${cakeDraft.cakeTitle}")
                     val cakeId = cakeRepository.insertCake(
@@ -190,7 +256,6 @@ class NewOrderViewModel(
                     ).toInt()
                     Log.d(TAG, "Cake inserted successfully. ID: $cakeId")
 
-                    // C. Loop Tiers
                     cakeDraft.tiers.forEach { tierDraft ->
                         Log.d(TAG, "Inserting Tier level ${tierDraft.level} for Cake ID: $cakeId")
                         val shapeId = getShapeId(tierDraft.shape)
@@ -208,8 +273,8 @@ class NewOrderViewModel(
                         )
                     }
                 }
-                
-                Log.d(TAG, "Full recursive save complete. Resetting draft and calling onSuccess.")
+
+                Log.d(TAG, "Save complete. Resetting draft and calling onSuccess.")
                 scheduleOrderAlarms(orderId.toString(), orderDraft.deliveryDate)
                 resetDraft()
                 onSuccess()


### PR DESCRIPTION
### Fixes

**1. Edit Order — adding/modifying cakes lost on navigation pop**

- **Root cause:** Navigation Compose 2.8.3 disposes invisible composables. When navigating `EDIT_ORDER → NEW_CAKE → popBackStack`, the `EDIT_ORDER` composable was recreated, causing `LaunchedEffect(editOrderId)` to re-fire `initForEdit()`, which reloaded the original DB data and overwrote any in-memory cake additions/edits.
- **Fix:** Added `initializedEditOrderId` guard in `NewOrderViewModel`. `initForEdit()` now skips if already initialized for the same order ID. Cleared in `resetDraft()` for fresh state on new order flows.

**2. Delivery Date card now shows time**

- **Change:** `formatDisplayDate` in `OrderDetailScreen` appends the time (e.g. `" at 14:30"`) when the input date string contains a time component. Both the "Data Ordenadu" and "Data Entrega" cards benefit from this.

### Features

**3. Dashboard now displays real data from the database**

- **What changed:** The DashboardScreen previously showed hardcoded/template values. It now uses a `DashboardViewModel` that queries the database for live data.
- **New files:**
  - `DashboardUiState.kt` — State data class with `TimelineItem` and `PickupItem` display models
  - `DashboardViewModel.kt` — Combines 8 Room flows (order counts by status, total revenue, client count, today orders, upcoming orders) and processes them into display-ready data
  - `DashboardViewModelFactory.kt` — Standard factory (matches existing manual DI pattern)
- **Modified files:**
  - `OrderDao.kt` / `ClientDao.kt` — Added aggregate queries (`countByStatus`, `getTotalRevenue`, `countClients`, date-filtered `OrderWithCakes` queries)
  - `OrderRepository.kt` / `ClientRepository.kt` — Repository wrappers for new DAO methods
  - `DashboardScreen.kt` — Now accepts `DashboardViewModel`, reads state via `collectAsStateWithLifecycle()`, replaces all hardcoded data with live state
  - `NavGraph.kt` / `MainActivity.kt` — Wired up `DashboardViewModel` through the dependency chain


Fixes #173 
Fixes #156 