### PR TITLE
feat: pre-fill client name when creating new order from ClientDetailScreen

### DIFF
--- a/app/src/main/java/com/example/ordermanagementcake/ui/clients/ClientDetailScreen.kt
+++ b/app/src/main/java/com/example/ordermanagementcake/ui/clients/ClientDetailScreen.kt
@@ -33,7 +33,8 @@ fun ClientDetail(
     clientWithOrders: ClientWithOrders?,
     onBackClick: () -> Unit = {},
     onDeleteClick: () -> Unit = {},
-    onUpdateClient: (ClientEntity) -> Unit = {}
+    onUpdateClient: (ClientEntity) -> Unit = {},
+    onNewOrderClick: (clientName: String) -> Unit = {}
 ) {
     if (clientWithOrders == null) {
         Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
@@ -130,6 +131,7 @@ fun ClientDetail(
             ActionButton(
                 icon = Icons.Default.Add,
                 label = "Enkomenda",
+                onClick = { onNewOrderClick(client.name) },
                 modifier = Modifier.weight(1f),
                 containerColor = MaterialTheme.colorScheme.primary,
                 contentColor = MaterialTheme.colorScheme.onPrimary

--- a/app/src/main/java/com/example/ordermanagementcake/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/example/ordermanagementcake/ui/navigation/NavGraph.kt
@@ -384,6 +384,11 @@ fun AppNavHost(
                         onBackClick = { navController.popBackStack() },
                         onUpdateClient = { updatedClient ->
                             clientViewModel.updateClient(updatedClient)
+                        },
+                        onNewOrderClick = { clientName ->
+                            newOrderViewModel.resetDraft()
+                            newOrderViewModel.setInitialClientName(clientName)
+                            navController.navigate(Routes.NEW_ORDER)
                         }
                     )
                 }

--- a/app/src/main/java/com/example/ordermanagementcake/ui/orders/NewOrderViewModel.kt
+++ b/app/src/main/java/com/example/ordermanagementcake/ui/orders/NewOrderViewModel.kt
@@ -121,6 +121,14 @@ class NewOrderViewModel(
         updateOrderDraft { it.copy(clientId = client.id, clientName = client.name) }
     }
 
+    fun setInitialClientName(clientName: String) {
+        _searchQuery.value = clientName
+        updateOrderDraft { it.copy(clientName = clientName) }
+        viewModelScope.launch {
+            clientRepository.getClientByName(clientName)?.let { selectClient(it) }
+        }
+    }
+
     fun updateOrderDraft(update: (OrderDraft) -> OrderDraft) {
         orderDraft = update(orderDraft)
     }


### PR DESCRIPTION
The Enkomenda button on ClientDetailScreen now navigates to the new order form with the current client pre-filled and auto-selected.

Changes:
- Added `onNewOrderClick` callback to `ClientDetail` composable
- Wired the Enkomenda button `onClick` to pass `client.name`
- Added `setInitialClientName()` to `NewOrderViewModel` for synchronous name + async ID resolution
- NavGraph resets the draft and pre-fills before navigating to `Routes.NEW_ORDER`