### PR TITLE
feat: navigate to order detail when tapping notification

### DIFF
--- a/app/src/main/java/com/example/ordermanagementcake/MainActivity.kt
+++ b/app/src/main/java/com/example/ordermanagementcake/MainActivity.kt
@@ -49,9 +49,13 @@ import android.Manifest
 import android.content.pm.PackageManager
 import android.os.Build
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.LaunchedEffect
 import androidx.core.content.ContextCompat
+import com.example.ordermanagementcake.notifications.AlarmSchedulerImpl
 
 class MainActivity : ComponentActivity() {
+
+    private var pendingNavigation by mutableStateOf<String?>(null)
 
     private val requestPermissionLauncher = registerForActivityResult(
         ActivityResultContracts.RequestPermission()
@@ -74,11 +78,22 @@ class MainActivity : ComponentActivity() {
         }
     }
 
+    override fun onNewIntent(intent: android.content.Intent) {
+        super.onNewIntent(intent)
+        handleNotificationIntent(intent)
+    }
+
+    private fun handleNotificationIntent(intent: android.content.Intent?) {
+        val orderId = intent?.getStringExtra(AlarmSchedulerImpl.EXTRA_ORDER_ID)?.toIntOrNull() ?: return
+        pendingNavigation = Routes.orderDetail(orderId)
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
 
         askNotificationPermission()
+        handleNotificationIntent(intent)
 
         val notificationHelper = com.example.ordermanagementcake.notifications.NotificationHelper(this)
         notificationHelper.createNotificationChannel()
@@ -140,6 +155,16 @@ class MainActivity : ComponentActivity() {
 
             OrderManagementCakeTheme(darkTheme = darkTheme) {
                 val navController = rememberNavController()
+
+                LaunchedEffect(pendingNavigation) {
+                    pendingNavigation?.let { route ->
+                        navController.navigate(route) {
+                            popUpTo(Routes.DASHBOARD)
+                        }
+                        pendingNavigation = null
+                    }
+                }
+
                 AppNavHost(
                     navController = navController,
                     dashboardViewModel = dashboardViewModel,

--- a/app/src/main/java/com/example/ordermanagementcake/notifications/NotificationHelper.kt
+++ b/app/src/main/java/com/example/ordermanagementcake/notifications/NotificationHelper.kt
@@ -29,6 +29,7 @@ class NotificationHelper(private val context: Context) {
     fun showNotification(orderId: String, message: String) {
         val intent = Intent(context, MainActivity::class.java).apply {
             flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+            putExtra(AlarmSchedulerImpl.EXTRA_ORDER_ID, orderId)
         }
         val pendingIntent: PendingIntent = PendingIntent.getActivity(
             context,


### PR DESCRIPTION
**Problem:** Tapping an order reminder notification just opened the dashboard with no context.

**Changes:**
- `NotificationHelper.kt`: Added `AlarmSchedulerImpl.EXTRA_ORDER_ID` extra to the notification's content intent
- `MainActivity.kt`: Added `handleNotificationIntent()` + `LaunchedEffect` to extract the order ID and navigate via NavController to `Routes.orderDetail(orderId)`, with `popUpTo(Routes.DASHBOARD)` for a clean back stack

**Handles two cases:**
1. App launched fresh from notification → `onCreate` → `handleNotificationIntent(intent)`
2. App already running → `onNewIntent` → `handleNotificationIntent(intent)`