### PR TITLE
refactor: improve notification appearance and readability

### DIFF
--- a/app/src/main/java/com/example/ordermanagementcake/notifications/NotificationHelper.kt
+++ b/app/src/main/java/com/example/ordermanagementcake/notifications/NotificationHelper.kt
@@ -5,6 +5,7 @@ import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import android.graphics.Color
 import android.os.Build
 import androidx.core.app.NotificationCompat
 import com.example.ordermanagementcake.MainActivity
@@ -39,9 +40,11 @@ class NotificationHelper(private val context: Context) {
         )
 
         val builder = NotificationCompat.Builder(context, CHANNEL_ID)
-            .setSmallIcon(R.mipmap.ic_launcher) // Note: normally should be a transparent vector drawable
-            .setContentTitle("Order Reminder: $orderId")
+            .setSmallIcon(R.drawable.ic_notification)
+            .setContentTitle("Encomenda #$orderId")
             .setContentText(message)
+            .setStyle(NotificationCompat.BigTextStyle().bigText(message))
+            .setColor(Color.parseColor("#8F4C34"))
             .setPriority(NotificationCompat.PRIORITY_HIGH)
             .setContentIntent(pendingIntent)
             .setAutoCancel(true)

--- a/app/src/main/java/com/example/ordermanagementcake/ui/orders/NewOrderViewModel.kt
+++ b/app/src/main/java/com/example/ordermanagementcake/ui/orders/NewOrderViewModel.kt
@@ -354,8 +354,8 @@ class NewOrderViewModel(
             val timeInMillis = date.time
             val thirtyMinsInMillis = 30 * 60 * 1000L
             
-            val messageExact = "Order #$orderId is scheduled for delivery/pickup NOW!"
-            val message30 = "Order #$orderId is scheduled for delivery/pickup in 30 minutes."
+            val messageExact = "Pedidu #$orderId prontu atu entrega!"
+            val message30 = "Pedidu #$orderId tenki entrega iha minutu 30."
             
             alarmScheduler.scheduleAlarm(orderId, timeInMillis, messageExact, true)
             alarmScheduler.scheduleAlarm(orderId, timeInMillis - thirtyMinsInMillis, message30, false)

--- a/app/src/main/res/drawable/ic_notification.xml
+++ b/app/src/main/res/drawable/ic_notification.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M12,22c1.1,0 2,-0.9 2,-2h-4c0,1.1 0.89,2 2,2zM18,16v-5c0,-3.07 -1.64,-5.64 -4.5,-6.32V4c0,-0.83 -0.67,-1.5 -1.5,-1.5s-1.5,0.67 -1.5,1.5v0.68C7.63,5.36 6,7.92 6,11v5l-2,2v1h16v-1l-2,-2z"/>
+</vector>


### PR DESCRIPTION
Closes #188

**Changes:**

- **New vector icon** `res/drawable/ic_notification.xml` — simple white bell, proper monochrome format for notifications (replaces the launcher icon that could show as a white square)
- **Title** changed to "Encomenda #$orderId" (more user-friendly)
- **Added** `BigTextStyle` — notification now expands on pull-down for long messages
- **Added** `setColor(#8F4C34)` — icon tint matches app's primary brown
- **Message text** changed to Tetun: "Pedidu #$orderId prontu atu entrega!" and "...tenki entrega iha minutu 30."