### PR TITLE
fix: hide header and filter chips when search is focused to prevent keyboard obstruction

### DIFF
--- a/app/src/main/java/com/example/ordermanagementcake/ui/orders/OrderListScreen.kt
+++ b/app/src/main/java/com/example/ordermanagementcake/ui/orders/OrderListScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 
 import androidx.compose.ui.text.font.FontWeight
@@ -85,6 +86,7 @@ fun OrderListScreen(
     val statusLabels = listOf("Pendente", "Prosesu", "Prontu", "Kompleta")
 
     var searchText by remember { mutableStateOf("") }
+    var isSearchFocused by remember { mutableStateOf(false) }
 
     val filteredOrders = remember(uiState.orders, searchText) {
         if (searchText.isBlank()) uiState.orders
@@ -104,22 +106,24 @@ fun OrderListScreen(
         contentPadding = PaddingValues(bottom = 88.dp)
     ) {
         // Header
-        item {
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 20.dp, vertical = 24.dp)
-            ) {
-                Text(
-                    text = "Pedidu sira iha agora",
-                    style = MaterialTheme.typography.headlineMedium,
-                    fontWeight = FontWeight.ExtraBold
-                )
-                Text(
-                    text = "Jestiona ita-nia kriasaun kulinária",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.secondary
-                )
+        if (!isSearchFocused) {
+            item {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 20.dp, vertical = 24.dp)
+                ) {
+                    Text(
+                        text = "Pedidu sira iha agora",
+                        style = MaterialTheme.typography.headlineMedium,
+                        fontWeight = FontWeight.ExtraBold
+                    )
+                    Text(
+                        text = "Jestiona ita-nia kriasaun kulinária",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.secondary
+                    )
+                }
             }
         }
 
@@ -133,7 +137,8 @@ fun OrderListScreen(
                 shape = RoundedCornerShape(28.dp),
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 16.dp),
+                    .padding(horizontal = 16.dp)
+                    .onFocusChanged { isSearchFocused = it.isFocused },
                 colors = TextFieldDefaults.colors(
                     unfocusedContainerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f),
                     focusedContainerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f),
@@ -145,7 +150,8 @@ fun OrderListScreen(
         }
 
         // Filter Chips
-        item {
+        if (!isSearchFocused) {
+            item {
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -172,6 +178,7 @@ fun OrderListScreen(
                     )
                 }
             }
+        }
         }
 
         // Content


### PR DESCRIPTION
When the search field is focused and the keyboard appears, the header (title/subtitle) and filter chips are now hidden so the order list has full screen visibility.\n\nPreviously the keyboard would cover the filtered results, making them hard to see.