### PR TITLE
fix: hide header and filter chips with AnimatedVisibility on search focus

### DIFF
--- a/app/src/main/java/com/example/ordermanagementcake/data/local/dao/OrderDao.kt
+++ b/app/src/main/java/com/example/ordermanagementcake/data/local/dao/OrderDao.kt
@@ -21,6 +21,10 @@ interface OrderDao {
     fun getOrdersByStatus(status: OrderStatus): Flow<List<OrderEntity>>
 
     @Transaction
+    @Query("SELECT * FROM orders")
+    fun getAllOrdersWithCakes(): Flow<List<OrderWithCakes>>
+
+    @Transaction
     @Query("SELECT * FROM orders WHERE status = :status")
     fun getOrdersWithCakesByStatus(status: OrderStatus): Flow<List<OrderWithCakes>>
 

--- a/app/src/main/java/com/example/ordermanagementcake/data/repository/OrderRepository.kt
+++ b/app/src/main/java/com/example/ordermanagementcake/data/repository/OrderRepository.kt
@@ -10,6 +10,9 @@ import kotlinx.coroutines.flow.Flow
 
 class OrderRepository(private val orderDao: OrderDao) {
 
+    fun getAllOrdersWithCakes(): Flow<List<OrderWithCakes>> =
+        orderDao.getAllOrdersWithCakes()
+
     // Updated to return the relationship so we can see the Cake titles
     fun getOrdersWithCakesByStatus(status: OrderStatus): Flow<List<OrderWithCakes>> =
         orderDao.getOrdersWithCakesByStatus(status)

--- a/app/src/main/java/com/example/ordermanagementcake/ui/orders/OrderListScreen.kt
+++ b/app/src/main/java/com/example/ordermanagementcake/ui/orders/OrderListScreen.kt
@@ -1,6 +1,7 @@
 package com.example.ordermanagementcake.ui.orders
 
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.*
@@ -19,6 +20,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 
 import androidx.compose.ui.text.font.FontWeight
@@ -85,6 +87,7 @@ fun OrderListScreen(
     val statusLabels = listOf("Pendente", "Prosesu", "Prontu", "Kompleta")
 
     var searchText by remember { mutableStateOf("") }
+    var isSearchFocused by remember { mutableStateOf(false) }
 
     val filteredOrders = remember(uiState.orders, searchText) {
         if (searchText.isBlank()) uiState.orders
@@ -105,21 +108,23 @@ fun OrderListScreen(
     ) {
         // Header
         item {
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 20.dp, vertical = 24.dp)
-            ) {
-                Text(
-                    text = "Pedidu sira iha agora",
-                    style = MaterialTheme.typography.headlineMedium,
-                    fontWeight = FontWeight.ExtraBold
-                )
-                Text(
-                    text = "Jestiona ita-nia kriasaun kulinária",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.secondary
-                )
+            AnimatedVisibility(visible = !isSearchFocused) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 20.dp, vertical = 24.dp)
+                ) {
+                    Text(
+                        text = "Pedidu sira iha agora",
+                        style = MaterialTheme.typography.headlineMedium,
+                        fontWeight = FontWeight.ExtraBold
+                    )
+                    Text(
+                        text = "Jestiona ita-nia kriasaun kulinária",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.secondary
+                    )
+                }
             }
         }
 
@@ -133,7 +138,8 @@ fun OrderListScreen(
                 shape = RoundedCornerShape(28.dp),
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 16.dp),
+                    .padding(horizontal = 16.dp)
+                    .onFocusChanged { isSearchFocused = it.isFocused },
                 colors = TextFieldDefaults.colors(
                     unfocusedContainerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f),
                     focusedContainerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f),
@@ -146,30 +152,32 @@ fun OrderListScreen(
 
         // Filter Chips
         item {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(vertical = 16.dp)
-                    .horizontalScroll(rememberScrollState())
-                    .padding(horizontal = 16.dp),
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                statusFilters.forEachIndexed { index, status ->
-                    val isSelected = uiState.selectedStatus == status
-                    FilterChip(
-                        selected = isSelected,
-                        onClick = { viewModel.loadOrders(status) },
-                        label = { Text(statusLabels[index]) },
-                        colors = FilterChipDefaults.filterChipColors(
-                            selectedContainerColor = Color(0xFFF87146),
-                            selectedLabelColor = Color.White
-                        ),
-                        border = if (!isSelected) FilterChipDefaults.filterChipBorder(
-                            borderColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.5f),
-                            enabled = true,
-                            selected = false
-                        ) else null
-                    )
+            AnimatedVisibility(visible = !isSearchFocused) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 16.dp)
+                        .horizontalScroll(rememberScrollState())
+                        .padding(horizontal = 16.dp),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    statusFilters.forEachIndexed { index, status ->
+                        val isSelected = uiState.selectedStatus == status
+                        FilterChip(
+                            selected = isSelected,
+                            onClick = { viewModel.loadOrders(status) },
+                            label = { Text(statusLabels[index]) },
+                            colors = FilterChipDefaults.filterChipColors(
+                                selectedContainerColor = Color(0xFFF87146),
+                                selectedLabelColor = Color.White
+                            ),
+                            border = if (!isSelected) FilterChipDefaults.filterChipBorder(
+                                borderColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.5f),
+                                enabled = true,
+                                selected = false
+                            ) else null
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/example/ordermanagementcake/ui/orders/OrderListScreen.kt
+++ b/app/src/main/java/com/example/ordermanagementcake/ui/orders/OrderListScreen.kt
@@ -96,14 +96,17 @@ fun OrderListScreen(
         focusManager.clearFocus()
     }
 
-    val filteredOrders = remember(uiState.orders, searchText) {
-        if (searchText.isBlank()) uiState.orders
-        else uiState.orders.filter { owc ->
-            val o = owc.orders
-            val cake = owc.cakes.firstOrNull()
-            o.id.toString().contains(searchText, ignoreCase = true) ||
-            cake?.cakeTitle?.contains(searchText, ignoreCase = true) == true ||
-            o.orderNotes.contains(searchText, ignoreCase = true)
+    val filteredOrders = remember(uiState.orders, searchText, uiState.selectedStatus) {
+        if (searchText.isBlank()) {
+            uiState.orders.filter { it.orders.status == uiState.selectedStatus }
+        } else {
+            uiState.orders.filter { owc ->
+                val o = owc.orders
+                val cake = owc.cakes.firstOrNull()
+                o.id.toString().contains(searchText, ignoreCase = true) ||
+                cake?.cakeTitle?.contains(searchText, ignoreCase = true) == true ||
+                o.orderNotes.contains(searchText, ignoreCase = true)
+            }
         }
     }
 
@@ -172,7 +175,7 @@ fun OrderListScreen(
                         val isSelected = uiState.selectedStatus == status
                         FilterChip(
                             selected = isSelected,
-                            onClick = { viewModel.loadOrders(status) },
+                            onClick = { viewModel.selectStatus(status) },
                             label = { Text(statusLabels[index]) },
                             colors = FilterChipDefaults.filterChipColors(
                                 selectedContainerColor = Color(0xFFF87146),
@@ -231,7 +234,8 @@ fun OrderListScreen(
                         horizontalAlignment = Alignment.CenterHorizontally
                     ) {
                         Text(
-                            text = "La iha order ba estadu ne'e.",
+                            text = if (searchText.isBlank()) "La iha order ba estadu ne'e."
+                                   else "La iha order ne'e koresponde ba buka.",
                             style = MaterialTheme.typography.bodyLarge,
                             color = Color.Gray
                         )

--- a/app/src/main/java/com/example/ordermanagementcake/ui/orders/OrderListScreen.kt
+++ b/app/src/main/java/com/example/ordermanagementcake/ui/orders/OrderListScreen.kt
@@ -1,6 +1,7 @@
 package com.example.ordermanagementcake.ui.orders
 
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
@@ -22,6 +23,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalFocusManager
 
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -88,6 +90,11 @@ fun OrderListScreen(
 
     var searchText by remember { mutableStateOf("") }
     var isSearchFocused by remember { mutableStateOf(false) }
+    val focusManager = LocalFocusManager.current
+
+    BackHandler(enabled = isSearchFocused) {
+        focusManager.clearFocus()
+    }
 
     val filteredOrders = remember(uiState.orders, searchText) {
         if (searchText.isBlank()) uiState.orders

--- a/app/src/main/java/com/example/ordermanagementcake/ui/orders/OrderViewModel.kt
+++ b/app/src/main/java/com/example/ordermanagementcake/ui/orders/OrderViewModel.kt
@@ -17,14 +17,18 @@ class OrderViewModel(private val repository: OrderRepository) : ViewModel() {
     val uiState: StateFlow<OrderUiState> = _uiState.asStateFlow() // StateFlow, Immutable expose ba iha View
 
     init {
-        loadOrders(OrderStatus.PENDING)
+        loadAllOrders()
     }
 
-    fun loadOrders(status: OrderStatus) {
-        _uiState.update { it.copy(isLoading = it.orders.isEmpty(), selectedStatus = status, errorMessage = null) }
+    fun selectStatus(status: OrderStatus) {
+        _uiState.update { it.copy(selectedStatus = status) }
+    }
+
+    fun loadAllOrders() {
+        _uiState.update { it.copy(isLoading = true, errorMessage = null) }
         viewModelScope.launch {
-            repository.getOrdersWithCakesByStatus(status)
-                .catch { e -> // Erro message
+            repository.getAllOrdersWithCakes()
+                .catch { e ->
                     _uiState.update { it.copy(isLoading = false, errorMessage = e.message) }
                 }
                 .collect { ordersWithCakes ->


### PR DESCRIPTION
When the search field is focused and the keyboard appears, the header (title/subtitle) and filter chips now fade out via AnimatedVisibility instead of being removed from the LazyColumn. This prevents the flicker/glitch that occurred when conditionally adding/removing item blocks.